### PR TITLE
[WIP] first basic graphql integration for the Individual model

### DIFF
--- a/chord_metadata_service/metadata/schema.py
+++ b/chord_metadata_service/metadata/schema.py
@@ -1,0 +1,10 @@
+import graphene
+
+import chord_metadata_service.patients.schema
+
+
+class Query(chord_metadata_service.patients.schema.Query, graphene.ObjectType):
+    pass
+
+
+schema = graphene.Schema(query=Query)

--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -88,6 +88,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'django_nose',
     'rest_framework_swagger',
+    'graphene_django',
 ]
 
 MIDDLEWARE = [
@@ -241,3 +242,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Graphene / Graphql conf
+GRAPHENE = {
+    'SCHEMA': 'chord_metadata_service.metadata.schema.schema'
+}

--- a/chord_metadata_service/metadata/urls.py
+++ b/chord_metadata_service/metadata/urls.py
@@ -17,6 +17,7 @@ from django.contrib import admin
 from django.urls import path, include
 from chord_metadata_service.restapi import api_views, urls as restapi_urls
 from chord_metadata_service.chord import urls as chord_urls
+from graphene_django.views import GraphQLView
 from rest_framework.schemas import get_schema_view
 from rest_framework_swagger.views import get_swagger_view
 
@@ -38,4 +39,7 @@ urlpatterns = [
     path('service-info', api_views.service_info, name="service-info"),
     *chord_urls.urlpatterns,  # TODO: Use include? can we double up?
     *([path('admin/', admin.site.urls)] if DEBUG else []),
+    # TODO: you most likely want to turn off the graphiql option in production
+    path('graphql/', GraphQLView.as_view(graphiql=True)),
+
 ]

--- a/chord_metadata_service/patients/schema.py
+++ b/chord_metadata_service/patients/schema.py
@@ -1,0 +1,46 @@
+import django_filters
+from django.contrib.postgres.fields import ArrayField
+from graphene_django_extras.types import DjangoObjectType
+from graphene_django_extras import DjangoFilterListField
+
+from chord_metadata_service.patients.models import (
+    Individual
+)
+
+
+class IndividualTypeFilter(django_filters.FilterSet):
+    # So every "complex" fields will need some special handling
+    # such as this ArrayField
+    alternate_ids = django_filters.CharFilter(lookup_expr=['icontains'])
+
+    class Meta:
+        model = Individual
+        fields = [
+            'id',
+            'alternate_ids',
+            'sex',
+            'ethnicity'
+        ]
+
+
+class IndividualType(DjangoObjectType):
+    class Meta:
+        model = Individual
+        # Avoiding the more "complex" fields for now
+        exclude_fields = [
+            'age', 
+            'karnofsky', 
+            'extra_properties', 
+            'taxonomy',
+            'comorbid_condition',
+            'ecog_performance_status'
+        ]
+        filterset_class = IndividualTypeFilter
+        # Next is the more usual way of filtering with graphene_django
+        filter_fields = {
+            "id": ("exact",)
+        }
+
+
+class Query:
+    individuals = DjangoFilterListField(IndividualType)

--- a/chord_metadata_service/patients/schema.py
+++ b/chord_metadata_service/patients/schema.py
@@ -1,5 +1,4 @@
 import django_filters
-from django.contrib.postgres.fields import ArrayField
 from graphene_django_extras.types import DjangoObjectType
 from graphene_django_extras import DjangoFilterListField
 
@@ -28,9 +27,9 @@ class IndividualType(DjangoObjectType):
         model = Individual
         # Avoiding the more "complex" fields for now
         exclude_fields = [
-            'age', 
-            'karnofsky', 
-            'extra_properties', 
+            'age',
+            'karnofsky',
+            'extra_properties',
             'taxonomy',
             'comorbid_condition',
             'ecog_performance_status'

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,8 @@ entrypoints==0.3
 fhirclient==3.2.0
 filelock==3.0.12
 flake8==3.8.3
+graphene-django==2.13.0
+graphene-django-extras==0.4.9
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==1.7.0


### PR DESCRIPTION
Alright so please view this PR as a sample of what a GraphQL integration into this service would look like. Currently this creates a new endpoint for graphql queries with only the Individual model being available. This is more or less the same setup I've used for a preliminary metadata service for CanDIGv2 (https://github.com/CanDIG/metadata_service_v2).

If GraphQL is to be introduced into CanDIG / Bento, something else to consider is the other part of my earlier implementation, this service (https://github.com/CanDIG/candig_search_service/) which aggregates data from multiple services: the interface is in GraphQL but each data source may or may not be accessed in GraphQL. This service also implements GraphQL with a totally different library than this current PR, graphene_django being quick to plug-in on top of Django's ORM but tartiflette being more flexible in its implementation.

So yeah, it could be that you'd want GraphQL in the stack but not necessarily in each services. Food for thought.