### PR TITLE
Set cors to an empty list

### DIFF
--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -103,13 +103,7 @@ MIDDLEWARE = [
     'chord_metadata_service.restapi.middleware.CandigAuthzMiddleware',
 ]
 
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:8000",
-    "http://localhost:8080",
-    "http://127.0.0.1",
-    "http://127.0.0.1:8000",
-    "http://127.0.0.1:8080",
-]
+CORS_ALLOWED_ORIGINS = []
 
 ROOT_URLCONF = 'chord_metadata_service.metadata.urls'
 


### PR DESCRIPTION
CORS activated when the list is not empty.
To activate CORS add allowed url to a list, e.g.:
CORS_ALLOWED_ORIGINS = ["http://localhost:8080"]

Otherwise, keep it empty.
