### PR TITLE
Improve API filtering

### DIFF
--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -1,13 +1,46 @@
 import django_filters
+from django.db.models import Q
+
 from .models import Individual
 
 
 class IndividualFilter(django_filters.rest_framework.FilterSet):
     id = django_filters.AllValuesMultipleFilter()
     sex = django_filters.CharFilter(lookup_expr='iexact')
-    ethnicity = django_filters.CharFilter(lookup_expr='iexact')
-    # TODO select all patients with disease "Asthma"
+    karyotypic_sex = django_filters.CharFilter(lookup_expr='iexact')
+    ethnicity = django_filters.CharFilter(lookup_expr='icontains')
+    race = django_filters.CharFilter(lookup_expr='icontains')
+    # e.g. date_of_birth_after=1987-01-01&date_of_birth_before=1990-12-31
+    date_of_birth = django_filters.DateFromToRangeFilter()
+    # e.g. select all patients with disease "Asthma"
+    disease = django_filters.CharFilter(
+        method="filter_disease", field_name="phenopackets__diseases",
+        label="Disease"
+    )
+    # e.g. select all patients who have a symptom "dry cough"
+    found_phenotypic_feature = django_filters.CharFilter(
+        method="filter_found_phenotypic_feature", field_name="phenopackets__phenotypic_features",
+        label="Found phenotypic feature"
+    )
 
     class Meta:
         model = Individual
-        fields = ["id", "sex", "ethnicity"]
+        fields = ["id", "active", "deceased", "biosamples", "phenopackets"]
+
+    def filter_found_phenotypic_feature(self, qs, name, value):
+        """
+        Filters only found (present in a patient) Phenotypic features by id or label
+        """
+        qs = qs.filter(
+            Q(phenopackets__phenotypic_features__pftype__id__icontains=value) |
+            Q(phenopackets__phenotypic_features__pftype__label__icontains=value),
+            phenopackets__phenotypic_features__negated=False
+        ).distinct()
+        return qs
+
+    def filter_disease(self, qs, name, value):
+        qs = qs.filter(
+            Q(phenopackets__diseases__term__id__icontains=value) |
+            Q(phenopackets__diseases__term__label__icontains=value)
+        ).distinct()
+        return qs

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -6,6 +6,7 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
     id = django_filters.AllValuesMultipleFilter()
     sex = django_filters.CharFilter(lookup_expr='iexact')
     ethnicity = django_filters.CharFilter(lookup_expr='iexact')
+    # TODO select all patients with disease "Asthma"
 
     class Meta:
         model = Individual

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -12,7 +12,6 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
     race = django_filters.CharFilter(lookup_expr='icontains')
     # e.g. date_of_birth_after=1987-01-01&date_of_birth_before=1990-12-31
     date_of_birth = django_filters.DateFromToRangeFilter()
-    # e.g. select all patients with disease "Asthma"
     disease = django_filters.CharFilter(
         method="filter_disease", field_name="phenopackets__diseases",
         label="Disease"

--- a/chord_metadata_service/patients/tests/test_models.py
+++ b/chord_metadata_service/patients/tests/test_models.py
@@ -41,13 +41,9 @@ class IndividualTest(TestCase):
     def test_filtering(self):
         f = IndividualFilter()
         # all phenotypic feature constants have negated=True
-        result = f.filter_found_phenotypic_feature(Individual.objects.all(),
-                                                   "phenopackets",
-                                                   "proptosis")
+        result = f.filter_found_phenotypic_feature(Individual.objects.all(), "phenopackets", "proptosis")
         self.assertEqual(len(result), 0)
-        result = f.filter_found_phenotypic_feature(Individual.objects.all(),
-                                                   "phenopackets",
-                                                   "HP:0000520")
+        result = f.filter_found_phenotypic_feature(Individual.objects.all(), "phenopackets", "HP:0000520")
         self.assertEqual(len(result), 0)
         result = f.filter_disease(Individual.objects.all(), "phenopackets", "OMIM:164400")
         self.assertEqual(len(result), 1)

--- a/chord_metadata_service/patients/tests/test_models.py
+++ b/chord_metadata_service/patients/tests/test_models.py
@@ -1,17 +1,55 @@
 from django.test import TestCase
 from chord_metadata_service.patients.tests.es_mocks import es  # noqa: F401
+from chord_metadata_service.phenopackets.tests import constants as c
+from chord_metadata_service.phenopackets import models as m
+
 from ..models import Individual
+from ..filters import IndividualFilter
 
 
 class IndividualTest(TestCase):
     """ Test module for Individual model """
 
     def setUp(self):
-        Individual.objects.create(id='patient:1', sex='FEMALE', age={"age": "P25Y3M2D"})
-        Individual.objects.create(id='patient:2', sex='FEMALE', age={"age": "P45Y3M2D"})
+        self.individual_one = Individual.objects.create(id='patient:1', sex='FEMALE', age={"age": "P25Y3M2D"})
+        self.individual_two = Individual.objects.create(id='patient:2', sex='FEMALE', age={"age": "P45Y3M2D"})
+        self.meta_data = m.MetaData.objects.create(**c.VALID_META_DATA_1)
+        self.phenopacket = m.Phenopacket.objects.create(
+            id="phenopacket_id:1",
+            subject=self.individual_one,
+            meta_data=self.meta_data,
+        )
+        self.phenotypic_feature_1 = m.PhenotypicFeature.objects.create(
+            **c.valid_phenotypic_feature(phenopacket=self.phenopacket)
+        )
+        self.phenotypic_feature_2 = m.PhenotypicFeature.objects.create(
+            **c.valid_phenotypic_feature(phenopacket=self.phenopacket)
+        )
+        self.disease_1 = m.Disease.objects.create(**c.VALID_DISEASE_1)
+        self.phenopacket.diseases.set([self.disease_1])
 
     def test_individual(self):
         individual_one = Individual.objects.get(id='patient:1')
         individual_two = Individual.objects.get(id='patient:2')
         self.assertEqual(individual_one.sex, 'FEMALE')
         self.assertEqual(individual_two.age, {"age": "P45Y3M2D"})
+        number_of_pf_one = len(m.PhenotypicFeature.objects.filter(phenopacket__subject=individual_one))
+        self.assertEqual(number_of_pf_one, 2)
+        number_of_pf_two = len(m.PhenotypicFeature.objects.filter(phenopacket__subject=individual_two))
+        self.assertEqual(number_of_pf_two, 0)
+
+    def test_filtering(self):
+        f = IndividualFilter()
+        # all phenotypic feature constants have negated=True
+        result = f.filter_found_phenotypic_feature(Individual.objects.all(),
+                                                   "phenopackets",
+                                                   "proptosis")
+        self.assertEqual(len(result), 0)
+        result = f.filter_found_phenotypic_feature(Individual.objects.all(),
+                                                   "phenopackets",
+                                                   "HP:0000520")
+        self.assertEqual(len(result), 0)
+        result = f.filter_disease(Individual.objects.all(), "phenopackets", "OMIM:164400")
+        self.assertEqual(len(result), 1)
+        result = f.filter_disease(Individual.objects.all(), "phenopackets", "spinocerebellar ataxia")
+        self.assertEqual(len(result), 1)

--- a/chord_metadata_service/phenopackets/filters.py
+++ b/chord_metadata_service/phenopackets/filters.py
@@ -14,10 +14,20 @@ class MetaDataFilter(django_filters.rest_framework.FilterSet):
 
 class PhenotypicFeatureFilter(django_filters.rest_framework.FilterSet):
     description = django_filters.CharFilter(lookup_expr='icontains')
+    extra_properties_datatype = django_filters.CharFilter(
+        method="filter_extra_properties_datatype", field_name="extra_properties",
+        label="Extra properties datatype"
+    )
 
     class Meta:
         model = m.PhenotypicFeature
-        fields = ["id", "description", "negated", "biosample", "phenopacket"]
+        fields = ["id", "description", "negated", "biosample", "phenopacket", "extra_properties_datatype"]
+
+    def filter_extra_properties_datatype(self, qs, name, value):
+        # if there is "datatype" key in "extra_properties" field the filter will filter by value of this key
+        # if there is no "datatype" key in "extra_properties" returns 0 results
+        qs = m.PhenotypicFeature.objects.filter(extra_properties__datatype=value)
+        return qs
 
 
 class ProcedureFilter(django_filters.rest_framework.FilterSet):

--- a/chord_metadata_service/phenopackets/filters.py
+++ b/chord_metadata_service/phenopackets/filters.py
@@ -108,7 +108,7 @@ class ProcedureFilter(django_filters.rest_framework.FilterSet):
         method=filter_ontology_label, field_name="body_site",
         label="Body site label"
     )
-    biosample_id=django_filters.ModelMultipleChoiceFilter(
+    biosample_id = django_filters.ModelMultipleChoiceFilter(
         queryset=m.Biosample.objects.all(), widget=CSVWidget,
         field_name="biosample", method=filter_related_model_ids,
         label="Biosample ID"

--- a/chord_metadata_service/phenopackets/filters.py
+++ b/chord_metadata_service/phenopackets/filters.py
@@ -148,20 +148,13 @@ class BiosampleFilter(django_filters.rest_framework.FilterSet):
         method=filter_ontology, field_name="sampled_tissue", label="Sampled tissue"
     )
     taxonomy = django_filters.CharFilter(
-        method=filter_ontology, field_name="taxonomy", label="Taxonomy"
-    )
+        method=filter_ontology, field_name="taxonomy", label="Taxonomy")
     histological_diagnosis = django_filters.CharFilter(
-        method=filter_ontology, field_name="histological_diagnosis",
-        label="Histological diagnosis"
-    )
+        method=filter_ontology, field_name="histological_diagnosis", label="Histological diagnosis")
     tumor_progression = django_filters.CharFilter(
-        method=filter_ontology, field_name="tumor_progression",
-        label="Tumor progression"
-    )
+        method=filter_ontology, field_name="tumor_progression", label="Tumor progression")
     tumor_grade = django_filters.CharFilter(
-        method=filter_ontology, field_name="tumor_grade",
-        label="Tumor grade"
-    )
+        method=filter_ontology, field_name="tumor_grade", label="Tumor grade")
 
     class Meta:
         model = m.Biosample
@@ -169,12 +162,28 @@ class BiosampleFilter(django_filters.rest_framework.FilterSet):
 
 
 class PhenopacketFilter(django_filters.rest_framework.FilterSet):
-    # TODO filtering by all related objects
+    disease_type = django_filters.CharFilter(
+        method=filter_ontology, field_name="diseases__term", label="Disease type"
+    )
+    found_phenotypic_feature = django_filters.CharFilter(
+        method="filter_found_phenotypic_feature", field_name="phenotypic_features",
+        label="Found phenotypic feature"
+    )
 
     class Meta:
         model = m.Phenopacket
-        fields = ["id", "subject", "biosamples",
-                  "genes", "variants", "hts_files", "diseases"]
+        fields = ["id", "subject", "biosamples", "genes", "variants", "hts_files"]
+
+    def filter_found_phenotypic_feature(self, qs, name, value):
+        """
+        Filters only found (present in a patient) Phenotypic features by id or label
+        """
+        qs = qs.filter(
+            Q(phenotypic_features__pftype__id__icontains=value) |
+            Q(phenotypic_features__pftype__label__icontains=value),
+            phenotypic_features__negated=False
+        ).distinct()
+        return qs
 
 
 class GenomicInterpretationFilter(django_filters.rest_framework.FilterSet):
@@ -186,11 +195,13 @@ class GenomicInterpretationFilter(django_filters.rest_framework.FilterSet):
 
 
 class DiagnosisFilter(django_filters.rest_framework.FilterSet):
-    # TODO filtering by disease ontology id or label
+    disease_type = django_filters.CharFilter(
+        method=filter_ontology, field_name="disease__term", label="Disease type"
+    )
 
     class Meta:
         model = m.Diagnosis
-        fields = ["id", "disease"]
+        fields = ["id"]
 
 
 class InterpretationFilter(django_filters.rest_framework.FilterSet):

--- a/chord_metadata_service/phenopackets/filters.py
+++ b/chord_metadata_service/phenopackets/filters.py
@@ -92,7 +92,6 @@ class PhenotypicFeatureFilter(django_filters.rest_framework.FilterSet):
                          Q(evidence__evidence_code__label__icontains=value))
 
 
-
 class ProcedureFilter(django_filters.rest_framework.FilterSet):
     code = django_filters.CharFilter(
         method=filter_ontology, field_name="code",

--- a/chord_metadata_service/phenopackets/filters.py
+++ b/chord_metadata_service/phenopackets/filters.py
@@ -24,7 +24,7 @@ def filter_related_model_ids(qs, name, value):
     """
     if value:
         lookup = "__".join([name, "in"])
-        qs = qs.filter(**{lookup: value})
+        qs = qs.filter(**{lookup: value}).distinct()
     return qs
 
 

--- a/chord_metadata_service/phenopackets/filters.py
+++ b/chord_metadata_service/phenopackets/filters.py
@@ -37,45 +37,30 @@ class MetaDataFilter(django_filters.rest_framework.FilterSet):
 
     class Meta:
         model = m.MetaData
-        fields = ["id", "created_by", "submitted_by", "phenopacket_schema_version"]
+        fields = ["id"]
 
 
 class PhenotypicFeatureFilter(django_filters.rest_framework.FilterSet):
     description = django_filters.CharFilter(lookup_expr="icontains")
-    type = django_filters.CharFilter(
-        method=filter_ontology, field_name="pftype",
-        label="Type"
-    )
-    severity = django_filters.CharFilter(
-        method=filter_ontology, field_name="severity",
-        label="Severity"
-    )
+    type = django_filters.CharFilter(method=filter_ontology, field_name="pftype", label="Type")
+    severity = django_filters.CharFilter(method=filter_ontology, field_name="severity", label="Severity")
     # TODO modifier
-    onset = django_filters.CharFilter(
-        method=filter_ontology, field_name="onset",
-        label="Onset"
-    )
-    evidence = django_filters.CharFilter(
-        method="filter_evidence", field_name="evidence",
-        label="Evidence"
-    )
+    onset = django_filters.CharFilter(method=filter_ontology, field_name="onset", label="Onset")
+    evidence = django_filters.CharFilter(method="filter_evidence", field_name="evidence", label="Evidence")
     # TODO not all projects will have datatype depending on the requirements
     extra_properties_datatype = django_filters.CharFilter(
         method="filter_extra_properties_datatype", field_name="extra_properties",
         label="Extra properties datatype"
     )
-    # TODO naming is not consistent individual_id vs phenopacket
-    individual_id = django_filters.ModelMultipleChoiceFilter(
+    individual = django_filters.ModelMultipleChoiceFilter(
         queryset=Individual.objects.all(), widget=CSVWidget,
         field_name="phenopacket__subject", method=filter_related_model_ids,
-        label="Individual ID"
+        label="Individual"
     )
 
     class Meta:
         model = m.PhenotypicFeature
-        fields = ["id", "description", "type", "severity", "onset",
-                  "evidence", "negated", "biosample", "phenopacket",
-                  "extra_properties_datatype", "individual_id"]
+        fields = ["id", "negated", "biosample", "phenopacket"]
 
     def filter_extra_properties_datatype(self, qs, name, value):
         """
@@ -93,34 +78,26 @@ class PhenotypicFeatureFilter(django_filters.rest_framework.FilterSet):
 
 
 class ProcedureFilter(django_filters.rest_framework.FilterSet):
-    code = django_filters.CharFilter(
-        method=filter_ontology, field_name="code",
-        label="Code"
-    )
-    body_site = django_filters.CharFilter(
-        method=filter_ontology, field_name="body_site",
-        label="Body site"
-    )
-    biosample_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=m.Biosample.objects.all(), widget=CSVWidget,
-        field_name="biosample", method=filter_related_model_ids,
-        label="Biosample ID"
+    code = django_filters.CharFilter(method=filter_ontology, field_name="code", label="Code")
+    body_site = django_filters.CharFilter(method=filter_ontology, field_name="body_site",label="Body site")
+    biosample = django_filters.ModelMultipleChoiceFilter(
+        queryset=m.Biosample.objects.all(), widget=CSVWidget, field_name="biosample",
+        method=filter_related_model_ids, label="Biosample"
     )
 
     class Meta:
         model = m.Procedure
-        fields = ["id", "code", "body_site", "biosample_id"]
+        fields = ["id"]
 
 
 class HtsFileFilter(django_filters.rest_framework.FilterSet):
-    uri = django_filters.CharFilter(lookup_expr="exact")
     description = django_filters.CharFilter(lookup_expr="icontains")
     hts_format = django_filters.CharFilter(lookup_expr="iexact")
     genome_assembly = django_filters.CharFilter(lookup_expr="iexact")
 
     class Meta:
         model = m.HtsFile
-        fields = ["uri", "description", "hts_format", "genome_assembly"]
+        fields = ["uri"]
 
 
 class GeneFilter(django_filters.rest_framework.FilterSet):
@@ -132,13 +109,17 @@ class GeneFilter(django_filters.rest_framework.FilterSet):
 
 class VariantFilter(django_filters.rest_framework.FilterSet):
     allele_type = django_filters.CharFilter(lookup_expr="iexact")
+    zygosity = django_filters.CharFilter(method=filter_ontology, field_name="zygosity", label="Zygosity")
 
     class Meta:
         model = m.Variant
-        fields = ["id", "allele_type"]
+        fields = ["id"]
 
 
 class DiseaseFilter(django_filters.rest_framework.FilterSet):
+    term = django_filters.CharFilter(method=filter_ontology, field_name="term", label="Term")
+    # TODO extra_properties 1. datatype 2. comorbidities_group
+    # TODO select all patients with disease "Asthma"
 
     class Meta:
         model = m.Disease
@@ -147,13 +128,26 @@ class DiseaseFilter(django_filters.rest_framework.FilterSet):
 
 class BiosampleFilter(django_filters.rest_framework.FilterSet):
     description = django_filters.CharFilter(lookup_expr="icontains")
+    sampled_tissue = django_filters.CharFilter(
+        method=filter_ontology, field_name="sampled_tissue", label="Sampled tissue"
+    )
+    taxonomy = django_filters.CharFilter(
+        method=filter_ontology, field_name="taxonomy", label="Taxonomy"
+    )
+    histological_diagnosis = django_filters.CharFilter(
+        method=filter_ontology, field_name="histological_diagnosis",
+        label="Histological diagnosis"
+    )
+    # TODO procedure is self.id, how to know procedure id ? filter by term or id
+    # TODO rest
 
     class Meta:
         model = m.Biosample
-        fields = ["id", "description", "individual", "procedure", "is_control_sample"]
+        fields = ["id", "individual", "procedure", "is_control_sample"]
 
 
 class PhenopacketFilter(django_filters.rest_framework.FilterSet):
+    # TODO filtering by all related objects
 
     class Meta:
         model = m.Phenopacket
@@ -165,10 +159,11 @@ class GenomicInterpretationFilter(django_filters.rest_framework.FilterSet):
 
     class Meta:
         model = m.GenomicInterpretation
-        fields = ["id", "status", "gene", "variant"]
+        fields = ["id", "gene", "variant"]
 
 
 class DiagnosisFilter(django_filters.rest_framework.FilterSet):
+    # TODO filtering by disease ontology id or label
 
     class Meta:
         model = m.Diagnosis
@@ -180,4 +175,4 @@ class InterpretationFilter(django_filters.rest_framework.FilterSet):
 
     class Meta:
         model = m.Interpretation
-        fields = ["id", "resolution_status", "phenopacket"]
+        fields = ["id", "phenopacket"]

--- a/chord_metadata_service/phenopackets/filters.py
+++ b/chord_metadata_service/phenopackets/filters.py
@@ -79,7 +79,7 @@ class PhenotypicFeatureFilter(django_filters.rest_framework.FilterSet):
 
 class ProcedureFilter(django_filters.rest_framework.FilterSet):
     code = django_filters.CharFilter(method=filter_ontology, field_name="code", label="Code")
-    body_site = django_filters.CharFilter(method=filter_ontology, field_name="body_site",label="Body site")
+    body_site = django_filters.CharFilter(method=filter_ontology, field_name="body_site", label="Body site")
     biosample = django_filters.ModelMultipleChoiceFilter(
         queryset=m.Biosample.objects.all(), widget=CSVWidget, field_name="biosample",
         method=filter_related_model_ids, label="Biosample"

--- a/chord_metadata_service/phenopackets/filters.py
+++ b/chord_metadata_service/phenopackets/filters.py
@@ -55,11 +55,23 @@ class PhenotypicFeatureFilter(django_filters.rest_framework.FilterSet):
         method=filter_ontology_label, field_name="pftype",
         label="Type label"
     )
+    severity_id = django_filters.CharFilter(
+        method=filter_ontology_id, field_name="severity",
+        label="Severity ID"
+    )
+    severity_label = django_filters.CharFilter(
+        method=filter_ontology_label, field_name="severity",
+        label="Severity label"
+    )
+    # TODO modifier
+    # TODO onset
+    # TODO evidence
     # TODO not all projects will have datatype depending on the requirements
     extra_properties_datatype = django_filters.CharFilter(
         method="filter_extra_properties_datatype", field_name="extra_properties",
         label="Extra properties datatype"
     )
+    # TODO naming is not consistent individual_id vs phenopacket
     individual_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Individual.objects.all(), widget=CSVWidget,
         field_name="phenopacket__subject", method=filter_related_model_ids,

--- a/chord_metadata_service/phenopackets/filters.py
+++ b/chord_metadata_service/phenopackets/filters.py
@@ -57,7 +57,6 @@ class PhenotypicFeatureFilter(django_filters.rest_framework.FilterSet):
     # TODO modifier
     onset = django_filters.CharFilter(method=filter_ontology, field_name="onset", label="Onset")
     evidence = django_filters.CharFilter(method="filter_evidence", field_name="evidence", label="Evidence")
-    # TODO not all projects will have datatype depending on the requirements
     extra_properties_datatype = django_filters.CharFilter(
         method=filter_extra_properties_datatype, field_name="extra_properties",
         label="Extra properties datatype"
@@ -162,8 +161,8 @@ class BiosampleFilter(django_filters.rest_framework.FilterSet):
 
 
 class PhenopacketFilter(django_filters.rest_framework.FilterSet):
-    disease_type = django_filters.CharFilter(
-        method=filter_ontology, field_name="diseases__term", label="Disease type"
+    disease = django_filters.CharFilter(
+        method=filter_ontology, field_name="diseases__term", label="Disease"
     )
     found_phenotypic_feature = django_filters.CharFilter(
         method="filter_found_phenotypic_feature", field_name="phenotypic_features",

--- a/chord_metadata_service/phenopackets/tests/constants.py
+++ b/chord_metadata_service/phenopackets/tests/constants.py
@@ -318,7 +318,8 @@ def valid_phenotypic_feature(biosample=None, phenopacket=None):
             }
         },
         extra_properties={
-            "comment": "test data"
+            "comment": "test data",
+            "datatype": "symptom"
         },
         biosample=biosample,
         phenopacket=phenopacket

--- a/chord_metadata_service/phenopackets/tests/test_models.py
+++ b/chord_metadata_service/phenopackets/tests/test_models.py
@@ -315,7 +315,7 @@ class PhenopacketTest(TestCase):
     def test_filtering(self):
         f = PhenopacketFilter()
         number_of_found_pf = len(m.Phenopacket.objects.filter(phenotypic_features__negated=False))
-        # all phenotypic feature constant has negated=True
+        # all phenotypic feature constants have negated=True
         result = f.filter_found_phenotypic_feature(m.Phenopacket.objects.all(), "phenotypic_features", "proptosis")
         self.assertEqual(len(result), 0)
         result = f.filter_found_phenotypic_feature(m.Phenopacket.objects.all(), "phenotypic_features", "HP:0000520")

--- a/chord_metadata_service/phenopackets/tests/test_models.py
+++ b/chord_metadata_service/phenopackets/tests/test_models.py
@@ -3,6 +3,14 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 
 from chord_metadata_service.resources.tests.constants import VALID_RESOURCE_1, VALID_RESOURCE_2
+from chord_metadata_service.phenopackets.filters import (
+    filter_ontology,
+    filter_extra_properties_datatype,
+    PhenotypicFeatureFilter,
+    DiseaseFilter,
+    PhenopacketFilter
+)
+
 from . import constants as c
 from .. import models as m
 
@@ -77,8 +85,27 @@ class PhenotypicFeatureTest(TestCase):
     def test_phenotypic_feature_str(self):
         self.assertEqual(str(self.phenotypic_feature_1), str(self.phenotypic_feature_1.id))
 
+    def test_filtering(self):
+        result = filter_ontology(m.PhenotypicFeature.objects.all(), "severity", "mild")
+        self.assertEqual(len(result), 2)
+        result = filter_ontology(m.PhenotypicFeature.objects.all(), "pftype", "HP:0000520")
+        self.assertEqual(len(result), 2)
+        f = PhenotypicFeatureFilter()
+        result = f.filter_evidence(m.PhenotypicFeature.objects.all(), "evidence__evidence_code", "ECO:0006017")
+        self.assertEqual(len(result), 2)
+        result = filter_extra_properties_datatype(m.PhenotypicFeature.objects.all(), "extra_properties", "complication")
+        self.assertEqual(len(result), 0)
+        result = filter_extra_properties_datatype(m.PhenotypicFeature.objects.all(), "extra_properties", "symptom")
+        self.assertEqual(len(result), 2)
+        f = PhenotypicFeatureFilter(queryset=m.PhenotypicFeature.objects.all(),
+                                    data={"individual": "patient:2,patient:1"})
+        result = f.qs
+        self.assertEqual(len(result), 1)
+
 
 class ProcedureTest(TestCase):
+    """ Test module for Procedure model. """
+
     def setUp(self):
         self.procedure_1 = m.Procedure.objects.create(**c.VALID_PROCEDURE_1)
         self.procedure_2 = m.Procedure.objects.create(**c.VALID_PROCEDURE_2)
@@ -93,6 +120,8 @@ class ProcedureTest(TestCase):
 
 
 class HtsFileTest(TestCase):
+    """ Test module for HtsFile model. """
+
     def setUp(self):
         self.hts_file = m.HtsFile.objects.create(**c.VALID_HTS_FILE)
 
@@ -105,6 +134,8 @@ class HtsFileTest(TestCase):
 
 
 class GeneTest(TestCase):
+    """ Test module for Gene model. """
+
     def setUp(self):
         self.gene_1 = m.Gene.objects.create(**c.VALID_GENE_1)
 
@@ -119,6 +150,8 @@ class GeneTest(TestCase):
 
 
 class VariantTest(TestCase):
+    """ Test module for Variant model. """
+
     def setUp(self):
         self.variant = m.Variant.objects.create(**c.VALID_VARIANT_1)
 
@@ -131,6 +164,8 @@ class VariantTest(TestCase):
 
 
 class DiseaseTest(TestCase):
+    """ Test module for Disease model. """
+
     def setUp(self):
         self.disease_1 = m.Disease.objects.create(**c.VALID_DISEASE_1)
 
@@ -141,8 +176,16 @@ class DiseaseTest(TestCase):
     def test_disease_str(self):
         self.assertEqual(str(self.disease_1), str(self.disease_1.id))
 
+    def test_filtering(self):
+        f = DiseaseFilter()
+        result = f.filter_extra_properties_cg(m.Disease.objects.all(),
+                                              "extra_properties__comorbidities_group", "immune")
+        self.assertEqual(len(result), 0)
+
 
 class GenomicInterpretationTest(TestCase):
+    """ Test module for GenomicInterpretation model. """
+
     def setUp(self):
         self.gene = m.Gene.objects.create(**c.VALID_GENE_1)
         self.variant = m.Variant.objects.create(**c.VALID_VARIANT_1)
@@ -165,6 +208,8 @@ class GenomicInterpretationTest(TestCase):
 
 
 class DiagnosisTest(TestCase):
+    """ Test module for Diagnosis model. """
+
     def setUp(self):
         self.disease = m.Disease.objects.create(**c.VALID_DISEASE_1)
 
@@ -192,6 +237,8 @@ class DiagnosisTest(TestCase):
 
 
 class InterpretationTest(TestCase):
+    """ Test module for Interpretation model. """
+
     def setUp(self):
         self.disease = m.Disease.objects.create(**c.VALID_DISEASE_1)
         self.diagnosis = m.Diagnosis.objects.create(**c.valid_diagnosis(
@@ -222,6 +269,8 @@ class InterpretationTest(TestCase):
 
 
 class MetaDataTest(TestCase):
+    """ Test module for MetaData model. """
+
     def setUp(self):
         self.resource_1 = m.Resource.objects.create(**VALID_RESOURCE_1)
         self.resource_2 = m.Resource.objects.create(**VALID_RESOURCE_2)
@@ -235,3 +284,44 @@ class MetaDataTest(TestCase):
 
     def test_metadata_str(self):
         self.assertEqual(str(self.metadata), str(self.metadata.id))
+
+
+class PhenopacketTest(TestCase):
+    """ Test module for Phenopacket model """
+
+    def setUp(self):
+        self.individual = m.Individual.objects.create(**c.VALID_INDIVIDUAL_1)
+        self.meta_data = m.MetaData.objects.create(**c.VALID_META_DATA_1)
+        self.phenopacket = m.Phenopacket.objects.create(
+            id="phenopacket_id:1",
+            subject=self.individual,
+            meta_data=self.meta_data,
+        )
+        self.phenotypic_feature_1 = m.PhenotypicFeature.objects.create(
+            **c.valid_phenotypic_feature(phenopacket=self.phenopacket)
+        )
+        self.phenotypic_feature_2 = m.PhenotypicFeature.objects.create(
+            **c.valid_phenotypic_feature(phenopacket=self.phenopacket)
+        )
+        self.disease_1 = m.Disease.objects.create(**c.VALID_DISEASE_1)
+        self.phenopacket.diseases.set([self.disease_1])
+
+    def test_phenopacket(self):
+        phenopacket = m.Phenopacket.objects.filter(id="phenopacket_id:1")
+        self.assertEqual(len(phenopacket), 1)
+        self.assertEqual(len(phenopacket.values("phenotypic_features")), 2)
+        self.assertEqual(len(phenopacket.values("diseases")), 1)
+
+    def test_filtering(self):
+        f = PhenopacketFilter()
+        number_of_found_pf = len(m.Phenopacket.objects.filter(phenotypic_features__negated=False))
+        # all phenotypic feature constant has negated=True
+        result = f.filter_found_phenotypic_feature(m.Phenopacket.objects.all(), "phenotypic_features", "proptosis")
+        self.assertEqual(len(result), 0)
+        result = f.filter_found_phenotypic_feature(m.Phenopacket.objects.all(), "phenotypic_features", "HP:0000520")
+        self.assertEqual(len(result), 0)
+        self.assertEqual(len(result), number_of_found_pf)
+        result_label = filter_ontology(m.Phenopacket.objects.all(), "diseases__term", "Spinocerebellar ataxia 1")
+        self.assertEqual(len(result_label), 1)
+        result_id = filter_ontology(m.Phenopacket.objects.all(), "diseases__term", "OMIM:164400")
+        self.assertEqual(len(result_label), len(result_id))


### PR DESCRIPTION
## General API filtering improvements

JSONField values that follow Ontology schema (`{"id": "concept_id", "label": "human readable label"}`) are filtered by both "id" or "label":

e.g phenotypic feature type

```
"type": {
    "id": "HP:0031246",
    "label": "Dry cough"
  }
```

can be found by any of the following:
`/api/phenotypicfeatures?type=Dry cough`

`/api/phenotypicfeatures?type=HP:0031246`
 
## Improved Phenotypic feature filtering

- filter by extra_properties datatype (if `datatype` key is not present returns 0):
e.g. select all symptom phenotypic features
`/api/phenotypicfeatures?extra_properties_datatype=symptom`
e.g. select only found symptoms for a patient with id 605-55-0521
`/api/phenotypicfeatures?negated=false&extra_properties_datatype=symptom&individual=605-55-0521`

## Improved Disease filtering

- filter by type:
`api/diseases?term=asthma`
`api/diseases?term=SNOMED:195967001`

- filter by datatype  (if `datatype` key is not present returns 0):
`api/diseases?extra_properties_datatype=comorbidity
`
- filter by comorbidities group:
e.g. select all cancer comorbidities:
`api/diseases?extra_properties_comorbidities_group=cancer`
e.g. select all cancer comorbidities for the individual with id 096-28-3812:
`api/diseases?extra_properties_comorbidities_group=cancer&individual=096-28-3812`

## Improved Phenopackets filtering

- filter by disease:
`api/phenopackets?disease=Asthma`

- filter by disease and found phenotypic feature:
e.g select all phenopackets with disease asthma and present symptom cough
`api/phenopackets?disease=Asthma&found_phenotypic_feature=cough`

## Improved Individuals filtering

- filter by date of birth range:
`api/individuals?date_of_birth_after=1987-01-01&date_of_birth_before=1990-12-31`

- filter by disease:
`/api/individuals?disease=Asthma`

- filter by found phenotypic feature:
`api/individuals?found_phenotypic_feature=dry+cough
`
