### PR TITLE
Fix filtering by biosample id in individuals

### DIFF
--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -24,7 +24,7 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
 
     class Meta:
         model = Individual
-        fields = ["id", "active", "deceased", "biosamples", "phenopackets"]
+        fields = ["id", "active", "deceased", "phenopackets__biosamples", "phenopackets"]
 
     def filter_found_phenotypic_feature(self, qs, name, value):
         """


### PR DESCRIPTION
In the ingestion workflow, biosamples are transmitted as a part of a phenopacket rather than an individual.
This PR fixes filtering by biosample id inside phenopacket.