### PR TITLE
Add full-text search endpoint

### DIFF
--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -26,7 +26,6 @@ class IndividualViewSet(viewsets.ModelViewSet):
     pagination_class = LargeResultsSetPagination
     renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, FHIRRenderer,
                         PhenopacketsRenderer, IndividualCSVRenderer)
-    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filter_class = IndividualFilter
     ordering_fields = ["id"]
-    search_fields = ["sex", "ethnicity"]

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -1,11 +1,15 @@
 import django_filters
 from django.db.models import Q
+from django.db.models import TextField
+from django.db.models.functions import Cast
+from django.contrib.postgres.search import SearchVector
 
 from .models import Individual
 
 
 class IndividualFilter(django_filters.rest_framework.FilterSet):
     id = django_filters.AllValuesMultipleFilter()
+    alternate_ids = django_filters.CharFilter(lookup_expr='icontains')
     sex = django_filters.CharFilter(lookup_expr='iexact')
     karyotypic_sex = django_filters.CharFilter(lookup_expr='iexact')
     ethnicity = django_filters.CharFilter(lookup_expr='icontains')
@@ -22,10 +26,12 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
         label="Found phenotypic feature"
     )
     extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
+    # full-text search at api/search
+    search = django_filters.CharFilter(method="filter_search", label="Search")
 
     class Meta:
         model = Individual
-        fields = ["id", "active", "deceased", "phenopackets__biosamples", "phenopackets"]
+        fields = ["id", "alternate_ids", "active", "deceased", "phenopackets__biosamples", "phenopackets"]
 
     def filter_found_phenotypic_feature(self, qs, name, value):
         """
@@ -47,3 +53,84 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
 
     def filter_extra_properties(self, qs, name, value):
         return qs.filter(extra_properties__icontains=value)
+
+    def filter_search(self, qs, name, value):
+        # creates index in db
+        qs = qs.annotate(
+            search=SearchVector("id", "alternate_ids", "date_of_birth",
+                                Cast("age", TextField()),
+                                "sex", "karyotypic_sex",
+                                Cast("taxonomy", TextField()),
+                                Cast("comorbid_condition", TextField()),
+                                Cast("ecog_performance_status", TextField()),
+                                Cast("karnofsky", TextField()),
+                                "ethnicity", "race",
+                                Cast("extra_properties", TextField()),
+
+                                # Phenotypic feature fields
+                                "phenopackets__phenotypic_features__description",
+                                Cast("phenopackets__phenotypic_features__pftype", TextField()),
+                                Cast("phenopackets__phenotypic_features__severity", TextField()),
+                                Cast("phenopackets__phenotypic_features__modifier", TextField()),
+                                Cast("phenopackets__phenotypic_features__onset", TextField()),
+                                Cast("phenopackets__phenotypic_features__evidence", TextField()),
+                                Cast("phenopackets__phenotypic_features__extra_properties", TextField()),
+
+                                # Biosample fields
+                                "phenopackets__biosamples__id",
+                                "phenopackets__biosamples__description",
+                                Cast("phenopackets__biosamples__sampled_tissue", TextField()),
+                                Cast("phenopackets__biosamples__taxonomy", TextField()),
+                                Cast("phenopackets__biosamples__individual_age_at_collection", TextField()),
+                                Cast("phenopackets__biosamples__histological_diagnosis", TextField()),
+                                Cast("phenopackets__biosamples__tumor_progression", TextField()),
+                                Cast("phenopackets__biosamples__tumor_grade", TextField()),
+                                Cast("phenopackets__biosamples__diagnostic_markers", TextField()),
+                                # Biosample Procedure fields
+                                Cast("phenopackets__biosamples__procedure__code", TextField()),
+                                Cast("phenopackets__biosamples__procedure__body_site", TextField()),
+                                Cast("phenopackets__biosamples__procedure__extra_properties", TextField()),
+                                Cast("phenopackets__biosamples__extra_properties", TextField()),
+                                # Biosample Variant fields
+                                "phenopackets__biosamples__variants__allele_type",
+                                Cast("phenopackets__biosamples__variants__allele", TextField()),
+                                Cast("phenopackets__biosamples__variants__zygosity", TextField()),
+                                Cast("phenopackets__biosamples__variants__extra_properties", TextField()),
+                                # Biosample HTS file fields
+                                "phenopackets__biosamples__hts_files__uri",
+                                "phenopackets__biosamples__hts_files__description",
+                                "phenopackets__biosamples__hts_files__hts_format",
+                                "phenopackets__biosamples__hts_files__genome_assembly",
+                                Cast("phenopackets__biosamples__hts_files__individual_to_sample_identifiers",
+                                     TextField()),
+                                Cast("phenopackets__biosamples__hts_files__extra_properties", TextField()),
+
+                                # Gene fields
+                                "phenopackets__genes__id",
+                                "phenopackets__genes__alternate_ids",
+                                "phenopackets__genes__symbol",
+                                Cast("phenopackets__genes__extra_properties", TextField()),
+
+                                # Variant fields
+                                "phenopackets__variants__allele_type",
+                                Cast("phenopackets__variants__allele", TextField()),
+                                Cast("phenopackets__variants__zygosity", TextField()),
+                                Cast("phenopackets__variants__extra_properties", TextField()),
+
+                                # Disease field
+                                Cast("phenopackets__diseases__term", TextField()),
+                                Cast("phenopackets__diseases__onset", TextField()),
+                                Cast("phenopackets__diseases__disease_stage", TextField()),
+                                Cast("phenopackets__diseases__tnm_finding", TextField()),
+                                Cast("phenopackets__diseases__extra_properties", TextField()),
+
+                                # HTS file fields
+                                "phenopackets__hts_files__uri",
+                                "phenopackets__hts_files__description",
+                                "phenopackets__hts_files__hts_format",
+                                "phenopackets__hts_files__genome_assembly",
+                                Cast("phenopackets__hts_files__individual_to_sample_identifiers", TextField()),
+                                Cast("phenopackets__hts_files__extra_properties", TextField()),
+                                )
+        ).filter(search=value).distinct("id")
+        return qs

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -26,7 +26,7 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
         label="Found phenotypic feature"
     )
     extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
-    # full-text search at api/search
+    # full-text search at api/individuals?search=
     search = django_filters.CharFilter(method="filter_search", label="Search")
 
     class Meta:

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -140,3 +140,22 @@ class IndividualCSVRendererTest(APITestCase):
         for column in ['id', 'sex', 'date of birth', 'taxonomy', 'karyotypic sex',
                        'race', 'ethnicity', 'age', 'diseases', 'created', 'updated']:
             self.assertIn(column, [column_name.lower() for column_name in headers])
+
+
+class IndividualFullTextSearchTest(APITestCase):
+    """ Test for api/individuals?search= """
+
+    def setUp(self):
+        self.individual_one = Individual.objects.create(**c.VALID_INDIVIDUAL)
+        self.individual_two = Individual.objects.create(**c.VALID_INDIVIDUAL_2)
+
+    def test_search(self):
+        get_resp_1 = self.client.get('/api/individuals?search=P49Y')
+        self.assertEqual(get_resp_1.status_code, status.HTTP_200_OK)
+        response_obj_1 = get_resp_1.json()
+        self.assertEqual(len(response_obj_1['results']), 1)
+
+        get_resp_2 = self.client.get('/api/individuals?search=NCBITaxon:9606')
+        self.assertEqual(get_resp_2.status_code, status.HTTP_200_OK)
+        response_obj_2 = get_resp_2.json()
+        self.assertEqual(len(response_obj_2['results']), 2)


### PR DESCRIPTION
This PR adds full-text search at `api/individuals?search=`.
The `filter_search ` method creates an index in the database that aggregates all Individual and Phenopacket fields and all fields of related objects.