### PR TITLE
fix: solve utc errors by keeping psycopg2 below 2.9

### DIFF
--- a/chord_metadata_service/package.cfg
+++ b/chord_metadata_service/package.cfg
@@ -1,4 +1,4 @@
 [package]
 name = katsu
-version = 1.3.7
+version = 1.3.8
 authors = Ksenia Zaytseva, David Lougheed, Simon Chénard, Romain Grégoire

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         "elasticsearch==7.8.0",
         "fhirclient>=3.2,<4.0",
         "jsonschema>=3.2,<4.0",
-        "psycopg2-binary>=2.8,<3.0",
+        "psycopg2-binary>=2.8,<2.9",
         "PyJWT[crypto]==1.7.1",
         "python-dateutil>=2.8,<3.0",
         "python-dotenv==0.14.0",


### PR DESCRIPTION
See https://stackoverflow.com/questions/68024060/assertionerror-database-connection-isnt-set-to-utc
Also see https://github.com/psycopg/psycopg2/issues/1293#issuecomment-862835147