### PR TITLE
Add mcode json workflow

### DIFF
--- a/chord_metadata_service/chord/workflows/mcode_json.wdl
+++ b/chord_metadata_service/chord/workflows/mcode_json.wdl
@@ -1,0 +1,20 @@
+workflow mcode_json {
+    File json_document
+
+    call identity_task {
+        input: json_document_in = json_document
+    }
+
+}
+
+task identity_task {
+    File json_document_in
+
+    command {
+        true
+    }
+
+    output {
+        File json_document = "${json_document_in}"
+    }
+}

--- a/examples/mcode_example.json
+++ b/examples/mcode_example.json
@@ -1,533 +1,151 @@
-{
-   "id":"8670db4d-77ad-4bee-b38c-599453510c6d",
-   "subject":{
-      "id":"6fcf56ed-8ad8-4395-a966-9ebee3822656"
-   },
-   "cancer_condition":{
-      "id":"5f2395f3-3271-441d-841a-af276c238eb0",
-      "clinical_status":{
-         "id":"http://terminology.hl7.org/CodeSystem/condition-clinical:active",
-         "label":"active"
-      },
-      "verification_status":{
-         "id":"http://terminology.hl7.org/CodeSystem/condition-ver-status:confirmed",
-         "label":"confirmed"
-      },
-      "code":{
-         "id":"http://snomed.info/sct:254837009",
-         "label":"Malignant neoplasm of breast (disorder)"
-      },
-      "date_of_diagnosis":"2019-03-02T22:02:57-05:00",
-      "condition_type":"primary",
-      "tnm_staging":[
-         {
-            "id":"63a13799-00cb-4c7c-afa9-d997df3dbcf8",
-            "cancer_condition":"5f2395f3-3271-441d-841a-af276c238eb0",
-            "stage_group":{
-               "data_value":{
-                  "id":"http://snomed.info/sct:261614003",
-                  "label":"Stage 2A (qualifier value)"
-               }
+[
+  {
+    "id": "8670db4d-77ad-4bee-b38c-599453510c6a",
+    "subject": {
+      "id": "ind:HG00096"
+    },
+    "cancer_condition": [
+      {
+        "id": "5f2395f3-3271-441d-841a-af276c238eb2",
+        "clinical_status": {
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical:active",
+          "label": "active"
+        },
+        "verification_status": {
+          "id": "http://terminology.hl7.org/CodeSystem/condition-ver-status:confirmed",
+          "label": "confirmed"
+        },
+        "code": {
+          "id": "http://snomed.info/sct:254837009",
+          "label": "Malignant neoplasm of breast (disorder)"
+        },
+        "date_of_diagnosis": "2019-03-02T22:02:57-05:00",
+        "condition_type": "primary",
+        "tnm_staging": [
+          {
+            "id": "63a13799-00cb-4c7c-afa9-d997df3dbcf2",
+            "cancer_condition": "5f2395f3-3271-441d-841a-af276c238eb2",
+            "stage_group": {
+              "data_value": {
+                "id": "http://snomed.info/sct:261614003",
+                "label": "Stage 2A (qualifier value)"
+              }
             },
-            "tnm_type":"clinical",
-            "primary_tumor_category":{
-               "data_value":{
-                  "id":"http://snomed.info/sct:67673008",
-                  "label":"T2 category (finding)"
-               }
+            "tnm_type": "clinical",
+            "primary_tumor_category": {
+              "data_value": {
+                "id": "http://snomed.info/sct:67673008",
+                "label": "T2 category (finding)"
+              }
             },
-            "regional_nodes_category":{
-               "data_value":{
-                  "id":"http://snomed.info/sct:62455006",
-                  "label":"N0 category (finding)"
-               }
+            "regional_nodes_category": {
+              "data_value": {
+                "id": "http://snomed.info/sct:62455006",
+                "label": "N0 category (finding)"
+              }
             },
-            "distant_metastases_category":{
-               "data_value":{
-                  "id":"http://snomed.info/sct:62455006",
-                  "label":"N0 category (finding)"
-               }
+            "distant_metastases_category": {
+              "data_value": {
+                "id": "http://snomed.info/sct:62455006",
+                "label": "N0 category (finding)"
+              }
             }
-         },
-         {
-            "id":"b19e1d7c-3f01-4933-b0f1-36f8ca2d5bbc",
-            "cancer_condition":"5f2395f3-3271-441d-841a-af276c238eb0",
-            "stage_group":{
-               "data_value":{
-                  "id":"http://snomed.info/sct:258219007",
-                  "label":"Stage 2 (qualifier value)"
-               }
+          },
+          {
+            "id": "b19e1d7c-3f01-4933-b0f1-36f8ca2d5bbw",
+            "cancer_condition": "5f2395f3-3271-441d-841a-af276c238eb2",
+            "stage_group": {
+              "data_value": {
+                "id": "http://snomed.info/sct:258219007",
+                "label": "Stage 2 (qualifier value)"
+              }
             },
-            "tnm_type":"clinical",
-            "primary_tumor_category":{
-               "data_value":{
-                  "id":"http://snomed.info/sct:67673008",
-                  "label":"T2 category (finding)"
-               }
+            "tnm_type": "clinical",
+            "primary_tumor_category": {
+              "data_value": {
+                "id": "http://snomed.info/sct:67673008",
+                "label": "T2 category (finding)"
+              }
             },
-            "regional_nodes_category":{
-               "data_value":{
-                  "id":"http://snomed.info/sct:62455006",
-                  "label":"N0 category (finding)"
-               }
+            "regional_nodes_category": {
+              "data_value": {
+                "id": "http://snomed.info/sct:62455006",
+                "label": "N0 category (finding)"
+              }
             },
-            "distant_metastases_category":{
-               "data_value":{
-                  "id":"http://snomed.info/sct:62455006",
-                  "label":"N0 category (finding)"
-               }
+            "distant_metastases_category": {
+              "data_value": {
+                "id": "http://snomed.info/sct:62455006",
+                "label": "N0 category (finding)"
+              }
             }
-         }
-      ]
-   },
-   "cancer_disease_status":{
-      "id":"http://snomed.info/sct:268910001",
-      "label":"Patient's condition improved"
-   },
-   "medication_statement": [
-      {
-      "id":"fd5416ee-78ad-41ea-b847-dcc3e975dec9",
-      "medication_code":{
-         "id":"http://www.nlm.nih.gov/research/umls/rxnorm:198240",
-         "label":"tamoxifen citrate 10 MG Oral Tablet"
+          }
+        ]
       }
-   }
-   ],
-   "tumor_marker":[
+    ],
+    "cancer_disease_status": {
+      "id": "http://snomed.info/sct:268910001",
+      "label": "Patient's condition improved"
+    },
+    "medication_statement": [
       {
-         "id":"9f785640-bdd2-4afe-93e2-3959b8994567",
-         "tumor_marker_code":{
-            "id":"http://loinc.org:48676-1",
-            "label":"HER2 [Interpretation] in Tissue"
-         },
-         "tumor_marker_data_value":{
-            "id":"http://snomed.info/sct:260385009",
-            "label":"Negative (qualifier value)"
-         },
-         "individual":"6fcf56ed-8ad8-4395-a966-9ebee3822656"
-      },
-      {
-         "id":"deeb6699-867b-4260-9d52-18b302bc42da",
-         "tumor_marker_code":{
-            "id":"http://loinc.org:48676-1",
-            "label":"HER2 [Interpretation] in Tissue"
-         },
-         "tumor_marker_data_value":{
-            "id":"http://snomed.info/sct:260385009",
-            "label":"Negative (qualifier value)"
-         },
-         "individual":"6fcf56ed-8ad8-4395-a966-9ebee3822656"
-      },
-      {
-         "id":"61f262ea-d3e9-4657-99c3-420d4b0f5280",
-         "tumor_marker_code":{
-            "id":"http://loinc.org:16112-5",
-            "label":"Estrogen receptor [Interpretation] in Tissue"
-         },
-         "tumor_marker_data_value":{
-            "id":"http://snomed.info/sct:10828004",
-            "label":"Positive (qualifier value)"
-         },
-         "individual":"6fcf56ed-8ad8-4395-a966-9ebee3822656"
-      },
-      {
-         "id":"6fa53768-cd9e-4633-b9e9-e6a3b264f145",
-         "tumor_marker_code":{
-            "id":"http://loinc.org:16113-3",
-            "label":"Progesterone receptor [Interpretation] in Tissue"
-         },
-         "tumor_marker_data_value":{
-            "id":"http://snomed.info/sct:260385009",
-            "label":"Negative (qualifier value)"
-         },
-         "individual":"6fcf56ed-8ad8-4395-a966-9ebee3822656"
+        "id": "fd5416ee-78ad-41ea-b847-dcc3e975dec5",
+        "medication_code": {
+          "id": "http://www.nlm.nih.gov/research/umls/rxnorm:198240",
+          "label": "tamoxifen citrate 10 MG Oral Tablet"
+        }
       }
-   ],
-   "cancer_related_procedures":[
+    ],
+    "tumor_marker": [
       {
-         "id":"910dba95-2870-4e83-9f0f-b16da9c39297",
-         "code":{
-            "id":"http://snomed.info/sct:69031006",
-            "label":"Excision of breast tissue (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"surgical"
+        "id": "9f785640-bdd2-4afe-93e2-3959b8994569",
+        "tumor_marker_code": {
+          "id": "http://loinc.org:48676-1",
+          "label": "HER2 [Interpretation] in Tissue"
+        },
+        "tumor_marker_data_value": {
+          "id": "http://snomed.info/sct:260385009",
+          "label": "Negative (qualifier value)"
+        },
+        "individual": "ind:HG00096"
       },
       {
-         "id":"2676fcea-a788-4dbd-97b2-57e30df8cc0f",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
+        "id": "deeb6699-867b-4260-9d52-18b302bc42de",
+        "tumor_marker_code": {
+          "id": "http://loinc.org:48676-1",
+          "label": "HER2 [Interpretation] in Tissue"
+        },
+        "tumor_marker_data_value": {
+          "id": "http://snomed.info/sct:260385009",
+          "label": "Negative (qualifier value)"
+        },
+        "individual": "ind:HG00096"
       },
       {
-         "id":"9b3fef9e-8860-4721-8f74-609fd173c10a",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"2d5367df-a102-4b18-b254-62fbdb1586ae",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"a7609255-0482-4b36-ad90-c821e863404d",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"83fdc3c6-7be8-422a-aa12-6252bcc54739",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"51f0d170-cfbf-4ffa-8d05-3f4565cca150",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"df19b727-fff0-4d5d-82bd-b9ddd7337dba",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"5ccc627a-aa39-418b-842c-23fc200d7510",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"93e6ed86-474b-4033-aae1-8547a0a63d23",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"5d4ade2d-53ad-489a-8336-a53c8693672c",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"03c7d064-63bc-46ef-adf3-fe64c5981d4e",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"d722684b-f0d9-4931-b3de-7f3638a6551e",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"168785f3-e7db-41c8-bb1d-a1aaef0e53e4",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"5f7736ab-86b8-43d0-88cf-243260d1cc01",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"b40ed30c-3ad7-468a-846a-1ab8ce682b64",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"1c645d66-1bb0-4e89-9322-34aefb59f0b8",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"a8889bc8-1523-4e79-aa4d-6026eeaa02bd",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"37cd7a3f-d4e2-48b1-be07-7126491e3aef",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"29e8e15f-9835-43fa-b76d-33d58a4b239c",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"3ebbde3e-6a23-4c13-9c65-ef7b899c1473",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"22265f09-ad9a-4c17-a450-27a0652ebba6",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"ff832c55-e38a-4b07-b40a-53d1767a0f0b",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"db38f007-6676-4449-a885-727bc358894a",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"74dd61a3-cd90-4f5b-a6f7-9ac485e7d43e",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"f1044644-8494-49e2-b6f8-2414467fe551",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"156be3f2-f228-448d-b54f-59fc671e05e2",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"424f3afb-3884-4a7d-af02-afdca441a644",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"46c576a4-196d-47e2-ad25-3d4333c8d1ea",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"11995568-c20e-45e4-9a03-64e6b17cacd7",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"12de0ba3-ccff-483d-b493-178b3d6f12ee",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"36cf5f93-1454-496c-b4d0-6a2166b188be",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"6d86fdb3-ef23-46b6-b478-552da5e12504",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"bc483d87-9735-4d70-ae6f-3433202943c1",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
-      },
-      {
-         "id":"833b7ae7-3111-4f0b-bc84-f57bad2cb6c0",
-         "code":{
-            "id":"http://snomed.info/sct:448385000",
-            "label":"Megavoltage radiation therapy using photons (procedure)"
-         },
-         "reason_reference":[
-            "5f2395f3-3271-441d-841a-af276c238eb0"
-         ],
-         "procedure_type":"radiation"
+        "id": "61f262ea-d3e9-4657-99c3-420d4b0f5283",
+        "tumor_marker_code": {
+          "id": "http://loinc.org:16112-5",
+          "label": "Estrogen receptor [Interpretation] in Tissue"
+        },
+        "tumor_marker_data_value": {
+          "id": "http://snomed.info/sct:10828004",
+          "label": "Positive (qualifier value)"
+        },
+        "individual": "ind:HG00096"
       }
-   ]
-}
+    ],
+    "cancer_related_procedures": [
+      {
+        "id": "910dba95-2870-4e83-9f0f-b16da9c39295",
+        "code": {
+          "id": "http://snomed.info/sct:69031006",
+          "label": "Excision of breast tissue (procedure)"
+        },
+        "reason_reference": [
+          "5f2395f3-3271-441d-841a-af276c238eb2"
+        ],
+        "procedure_type": "surgical"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds a workflow for ingesting mCODE json data that follows the internal Katsu mCODE-based schema.
The mcode_example.json is modified and linked to an individual from the [demo dataset](https://github.com/c3g/chord_demo_dataset).

Example POST body for ingest:
```
{
    "table_id": "12a6bd98-eebf-4701-9de8-50ed67c27387",
    "workflow_id": "mcode_json",
    "workflow_params": {
        "mcode_json.json_document": "examples/mcode_example.json"
    },
    "workflow_outputs": {
        "json_document": "examples/mcode_example.json"
    }
}
```