### PR TITLE
Add views caching

### DIFF
--- a/chord_metadata_service/experiments/api_views.py
+++ b/chord_metadata_service/experiments/api_views.py
@@ -3,6 +3,8 @@ from rest_framework.settings import api_settings
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from django_filters.rest_framework import DjangoFilterBackend
 
 from .serializers import ExperimentSerializer
@@ -27,6 +29,11 @@ class ExperimentViewSet(viewsets.ModelViewSet):
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES)
     filter_backends = [DjangoFilterBackend]
     filter_class = ExperimentFilter
+
+    # Cache page for the requested url for 2 hours
+    @method_decorator(cache_page(60 * 60 * 2))
+    def dispatch(self, *args, **kwargs):
+        return super(ExperimentViewSet, self).dispatch(*args, **kwargs)
 
 
 @api_view(["GET"])

--- a/chord_metadata_service/mcode/api_views.py
+++ b/chord_metadata_service/mcode/api_views.py
@@ -3,6 +3,8 @@ from rest_framework.settings import api_settings
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from .schemas import MCODE_SCHEMA
 from . import models as m, serializers as s
 from chord_metadata_service.restapi.api_renderers import PhenopacketsRenderer
@@ -12,6 +14,11 @@ from chord_metadata_service.restapi.pagination import LargeResultsSetPagination
 class McodeModelViewSet(viewsets.ModelViewSet):
     pagination_class = LargeResultsSetPagination
     renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, PhenopacketsRenderer)
+
+    # Cache page for the requested url for 2 hours
+    @method_decorator(cache_page(60 * 60 * 2))
+    def dispatch(self, *args, **kwargs):
+        return super(McodeModelViewSet, self).dispatch(*args, **kwargs)
 
 
 class GeneticSpecimenViewSet(McodeModelViewSet):

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -1,5 +1,7 @@
 from rest_framework import viewsets, filters
 from rest_framework.settings import api_settings
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from django_filters.rest_framework import DjangoFilterBackend
 from .serializers import IndividualSerializer
 from .models import Individual
@@ -29,3 +31,8 @@ class IndividualViewSet(viewsets.ModelViewSet):
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filter_class = IndividualFilter
     ordering_fields = ["id"]
+
+    # Cache page for the requested url for 2 hours
+    @method_decorator(cache_page(60*60*2))
+    def dispatch(self, *args, **kwargs):
+        return super(IndividualViewSet, self).dispatch(*args, **kwargs)

--- a/chord_metadata_service/phenopackets/api_views.py
+++ b/chord_metadata_service/phenopackets/api_views.py
@@ -4,6 +4,8 @@ from rest_framework.settings import api_settings
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from django_filters.rest_framework import DjangoFilterBackend
 
 from chord_metadata_service.restapi.api_renderers import PhenopacketsRenderer, FHIRRenderer
@@ -17,6 +19,11 @@ from . import models as m, serializers as s, filters as f
 class PhenopacketsModelViewSet(viewsets.ModelViewSet):
     renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, PhenopacketsRenderer)
     pagination_class = LargeResultsSetPagination
+
+    # Cache page for the requested url for 2 hours
+    @method_decorator(cache_page(60 * 60 * 2))
+    def dispatch(self, *args, **kwargs):
+        return super(PhenopacketsModelViewSet, self).dispatch(*args, **kwargs)
 
 
 class ExtendedPhenopacketsModelViewSet(PhenopacketsModelViewSet):
@@ -252,6 +259,8 @@ def get_chord_phenopacket_schema(_request):
     return Response(PHENOPACKET_SCHEMA)
 
 
+# Cache page for the requested url for 2 hours
+@cache_page(60 * 60 * 2)
 @api_view(["GET"])
 @permission_classes([OverrideOrSuperUserOnly])
 def phenopackets_overview(_request):

--- a/chord_metadata_service/phenopackets/api_views.py
+++ b/chord_metadata_service/phenopackets/api_views.py
@@ -293,7 +293,9 @@ def phenopackets_overview(_request):
         individuals_set.add(ind.id)
         individuals_sex.update((ind.sex,))
         individuals_k_sex.update((ind.karyotypic_sex,))
-        individuals_ethnicity.update((ind.ethnicity,))
+        # ethnicity is char field, check it's not empty
+        if ind.ethnicity != "":
+            individuals_ethnicity.update((ind.ethnicity,))
 
         # Generic Counter on all available extra properties
         if ind.extra_properties:
@@ -356,7 +358,6 @@ def phenopackets_overview(_request):
                 "age": dict(individuals_age),
                 "ethnicity": dict(individuals_ethnicity),
                 "extra_properties": dict(individuals_extra_prop),
-                # TODO: how to count age: it can be represented by three different schemas
             },
             "phenotypic_features": {
                 # count is a number of unique phenotypic feature types (not all pfs in the database)


### PR DESCRIPTION
This PR adds:
- basic cache for api view `overview` and for viewsets in phenopackets, patients, experiments and mcode apps
- small fix for ethnicity counter in overview in order to avoid adding empty key if ethnicity is empty