### PR TITLE
Fix search for experiments

### DIFF
--- a/chord_metadata_service/chord/tests/constants.py
+++ b/chord_metadata_service/chord/tests/constants.py
@@ -17,6 +17,8 @@ __all__ = [
     "TEST_SEARCH_QUERY_4",
     "TEST_SEARCH_QUERY_5",
     "TEST_SEARCH_QUERY_6",
+    "TEST_SEARCH_QUERY_7",
+    "TEST_SEARCH_QUERY_8",
     "TEST_FHIR_SEARCH_QUERY",
 ]
 
@@ -243,4 +245,6 @@ TEST_SEARCH_QUERY_4 = ["#eq", ["#resolve", "biosamples", "[item]", "sampled_tiss
 TEST_SEARCH_QUERY_5 = ["#ico", ["#resolve", "phenotypic_features", "[item]", "type", "label"], "proptosis"]
 TEST_SEARCH_QUERY_6 = ["#ico", ["#resolve", "biosamples", "[item]", "sampled_tissue", "label"],
                        "URINARY BLADDER"]
+TEST_SEARCH_QUERY_7 = ["#eq", ["#resolve", "experiment_results", "[item]", "file_format"], "VCF"]
+TEST_SEARCH_QUERY_8 = ["#ico", ["#resolve", "experiment_type"], "chromatin"]
 TEST_FHIR_SEARCH_QUERY = {"query": {"match": {"gender": "FEMALE"}}}

--- a/chord_metadata_service/experiments/search_schemas.py
+++ b/chord_metadata_service/experiments/search_schemas.py
@@ -9,7 +9,7 @@ from chord_metadata_service.restapi.search_schemas import ONTOLOGY_SEARCH_SCHEMA
 
 __all__ = ["EXPERIMENT_SEARCH_SCHEMA"]
 
-EXPERIMENT_RESULT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_RESULT, {
+EXPERIMENT_RESULT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_RESULT_SCHEMA, {
     "properties": {
         "identifier": {
             "search": search_optional_eq(0)
@@ -27,7 +27,7 @@ EXPERIMENT_RESULT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPE
             "search": search_optional_eq(4)
         },
         "usage": {
-            "search": search_optional_eq(5)
+            "search": search_optional_str(5)
         },
     },
     "search": {
@@ -113,6 +113,7 @@ EXPERIMENT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_
         "library_layout": {
             "search": search_optional_str(13),
         },
+        # query example: ["#ico", ["#resolve", "instrument", "model"], "Illumina"]
         "instrument": merge_schema_dictionaries(
             INSTRUMENT_SEARCH_SCHEMA,
             {"search": {"database": {
@@ -121,6 +122,29 @@ EXPERIMENT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_
                     "foreign_key": models.Experiment._meta.get_field("instrument").column
                 }
             }}}),
+        # query example: ["#ico", ["#resolve", "experiment_results", "[item]", "description"], "VCF file"]
+        "experiment_results": {
+            "items": merge_schema_dictionaries(
+                EXPERIMENT_RESULT_SEARCH_SCHEMA,
+                {"search": {"database": {
+                    "relationship": {
+                        "type": "MANY_TO_ONE",
+                        "foreign_key": "experimentresult_id"  # TODO: No hard-code, from M2M
+                    }
+                }}}
+            ),
+            "search": {
+                "database": {
+                    "relation": models.Experiment._meta.get_field(
+                        "experiment_results").remote_field.through._meta.db_table,
+                    "relationship": {
+                        "type": "ONE_TO_MANY",
+                        "parent_foreign_key": "experiment_id",  # TODO: No hard-code
+                        "parent_primary_key": models.Experiment._meta.pk.column
+                    }
+                }
+            }
+        },
     },
     "search": {
         "database": {

--- a/chord_metadata_service/experiments/search_schemas.py
+++ b/chord_metadata_service/experiments/search_schemas.py
@@ -7,8 +7,59 @@ from chord_metadata_service.restapi.schema_utils import (
 )
 from chord_metadata_service.restapi.search_schemas import ONTOLOGY_SEARCH_SCHEMA
 
-
 __all__ = ["EXPERIMENT_SEARCH_SCHEMA"]
+
+EXPERIMENT_RESULT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_RESULT, {
+    "properties": {
+        "identifier": {
+            "search": search_optional_eq(0)
+        },
+        "description": {
+            "search": search_optional_str(1)
+        },
+        "filename": {
+            "search": search_optional_str(2)
+        },
+        "file_format": {
+            "search": search_optional_eq(3)
+        },
+        "data_output_type": {
+            "search": search_optional_eq(4)
+        },
+        "usage": {
+            "search": search_optional_eq(5)
+        },
+    },
+    "search": {
+        "database": {
+            "primary_key": models.ExperimentResult._meta.pk.column,
+            "relation": models.ExperimentResult._meta.db_table,
+        }
+    }
+})
+
+INSTRUMENT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.INSTRUMENT_SCHEMA, {
+    "properties": {
+        "identifier": {
+            "search": search_optional_eq(0)
+        },
+        "platform": {
+            "search": search_optional_str(1)
+        },
+        "description": {
+            "search": search_optional_str(2)
+        },
+        "model": {
+            "search": search_optional_str(3)
+        },
+    },
+    "search": {
+        "database": {
+            "primary_key": models.Instrument._meta.pk.column,
+            "relation": models.Instrument._meta.db_table,
+        }
+    }
+})
 
 EXPERIMENT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_SCHEMA, {
     "properties": {
@@ -62,6 +113,14 @@ EXPERIMENT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_
         "library_layout": {
             "search": search_optional_str(13),
         },
+        "instrument": merge_schema_dictionaries(
+            INSTRUMENT_SEARCH_SCHEMA,
+            {"search": {"database": {
+                "relationship": {
+                    "type": "MANY_TO_ONE",
+                    "foreign_key": models.Experiment._meta.get_field("instrument").column
+                }
+            }}}),
     },
     "search": {
         "database": {

--- a/chord_metadata_service/experiments/search_schemas.py
+++ b/chord_metadata_service/experiments/search_schemas.py
@@ -3,12 +3,12 @@ from chord_metadata_service.restapi.schema_utils import (
     search_optional_eq,
     search_optional_str,
     tag_schema_with_search_properties,
+    merge_schema_dictionaries
 )
 from chord_metadata_service.restapi.search_schemas import ONTOLOGY_SEARCH_SCHEMA
 
 
 __all__ = ["EXPERIMENT_SEARCH_SCHEMA"]
-
 
 EXPERIMENT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_SCHEMA, {
     "properties": {
@@ -41,9 +41,11 @@ EXPERIMENT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_
         "library_strategy": {
             "search": search_optional_str(7),
         },
-        # TODO: other_fields: ?
         "biosample": {
-            "search": search_optional_eq(8, queryable="internal"),
+            "search": merge_schema_dictionaries(
+                search_optional_eq(8),
+                {"database": {"field": models.Experiment._meta.get_field("biosample").column}}
+            )
         },
         "extraction_protocol": {
             "search": search_optional_str(9),

--- a/chord_metadata_service/experiments/tests/constants.py
+++ b/chord_metadata_service/experiments/tests/constants.py
@@ -1,4 +1,4 @@
-def valid_experiment(biosample, instrument=None):
+def valid_experiment(biosample, instrument=None, table=None):
     return {
         "id": "experiment:1",
         "study_type": "Whole genome Sequencing",
@@ -15,7 +15,8 @@ def valid_experiment(biosample, instrument=None):
         "qc_flags": ["flag 1", "flag 2"],
         "extra_properties": {"some_field": "value"},
         "biosample": biosample,
-        "instrument": instrument
+        "instrument": instrument,
+        "table": table
     }
 
 

--- a/chord_metadata_service/package.cfg
+++ b/chord_metadata_service/package.cfg
@@ -1,4 +1,4 @@
 [package]
 name = katsu
-version = 2.1.2
+version = 2.2.0
 authors = Ksenia Zaytseva, David Lougheed, Simon Chénard, Romain Grégoire


### PR DESCRIPTION
This PR adds (and fixes some) more functionality for the experiment search.
New experiment search features:
- search by experiment result values
- search by instrument values

All those searches were tested from katsu.
What's not tested is the federation part - if the experiment array is added to the response.