### PR TITLE
Rename schema IDs, add a bunch of new ones

### DIFF
--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -1,5 +1,4 @@
 from .descriptions import EXPERIMENT, EXPERIMENT_RESULT, INSTRUMENT
-from chord_metadata_service.restapi.description_utils import describe_schema
 from chord_metadata_service.restapi.schemas import ONTOLOGY_CLASS_LIST, KEY_VALUE_OBJECT
 from chord_metadata_service.restapi.schema_utils import tag_ids_and_describe
 

--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -8,7 +8,7 @@ __all__ = ["EXPERIMENT_SCHEMA", "EXPERIMENT_RESULT_SCHEMA", "INSTRUMENT_SCHEMA"]
 
 EXPERIMENT_RESULT_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:experiment_result_schema",
+    "$id": "katsu:experiments:experiment_result",
     "title": "Experiment result schema",
     "description": "Schema for describing information about analysis of sequencing data in a file format.",
     "type": "object",
@@ -60,7 +60,7 @@ EXPERIMENT_RESULT_SCHEMA = describe_schema({
 
 INSTRUMENT_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:instrument_schema",
+    "$id": "katsu:experiments:instrument",
     "title": "Instrument schema",
     "description": "Schema for describing an instrument used for a sequencing experiment.",
     "type": "object",
@@ -84,7 +84,7 @@ INSTRUMENT_SCHEMA = describe_schema({
 
 EXPERIMENT_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:experiment_schema",
+    "$id": "katsu:experiments:experiment",
     "title": "Experiment schema",
     "description": "Schema for describing an experiment.",
     "type": "object",

--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -1,12 +1,13 @@
 from .descriptions import EXPERIMENT, EXPERIMENT_RESULT, INSTRUMENT
 from chord_metadata_service.restapi.description_utils import describe_schema
 from chord_metadata_service.restapi.schemas import ONTOLOGY_CLASS_LIST, KEY_VALUE_OBJECT
+from chord_metadata_service.restapi.schema_utils import tag_ids_and_describe
 
 
 __all__ = ["EXPERIMENT_SCHEMA", "EXPERIMENT_RESULT_SCHEMA", "INSTRUMENT_SCHEMA"]
 
 
-EXPERIMENT_RESULT_SCHEMA = describe_schema({
+EXPERIMENT_RESULT_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:experiments:experiment_result",
     "title": "Experiment result schema",
@@ -58,7 +59,7 @@ EXPERIMENT_RESULT_SCHEMA = describe_schema({
 }, EXPERIMENT_RESULT)
 
 
-INSTRUMENT_SCHEMA = describe_schema({
+INSTRUMENT_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:experiments:instrument",
     "title": "Instrument schema",
@@ -82,7 +83,7 @@ INSTRUMENT_SCHEMA = describe_schema({
 }, INSTRUMENT)
 
 
-EXPERIMENT_SCHEMA = describe_schema({
+EXPERIMENT_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:experiments:experiment",
     "title": "Experiment schema",

--- a/chord_metadata_service/mcode/schemas.py
+++ b/chord_metadata_service/mcode/schemas.py
@@ -4,7 +4,6 @@ from chord_metadata_service.restapi.schema_utils import (
     tag_ids_and_describe,
 )
 from chord_metadata_service.restapi.schemas import ONTOLOGY_CLASS, ONTOLOGY_CLASS_LIST, EXTRA_PROPERTIES_SCHEMA
-from chord_metadata_service.restapi.description_utils import describe_schema
 from chord_metadata_service.patients.schemas import INDIVIDUAL_SCHEMA
 from . import descriptions as d
 

--- a/chord_metadata_service/mcode/schemas.py
+++ b/chord_metadata_service/mcode/schemas.py
@@ -11,7 +11,7 @@ from . import descriptions as d
 # FHIR Quantity https://www.hl7.org/fhir/datatypes.html#Quantity
 QUANTITY = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:quantity_schema",
+    "$id": "katsu:mcode:quantity",
     "title": "Quantity schema",
     "description": "Schema for the datatype Quantity.",
     "type": "object",
@@ -39,7 +39,7 @@ QUANTITY = {
 # FHIR CodeableConcept https://www.hl7.org/fhir/datatypes.html#CodeableConcept
 CODEABLE_CONCEPT = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:codeable_concept_schema",
+    "$id": "katsu:mcode:codeable_concept",
     "title": "Codeable Concept schema",
     "description": "Schema for the datatype Concept.",
     "type": "object",
@@ -67,7 +67,7 @@ CODEABLE_CONCEPT = {
 # FHIR Period https://www.hl7.org/fhir/datatypes.html#Period
 PERIOD = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:period_schema",
+    "$id": "katsu:mcode:period",
     "title": "Period",
     "description": "Period schema.",
     "type": "object",
@@ -87,7 +87,7 @@ PERIOD = {
 # FHIR Ratio https://www.hl7.org/fhir/datatypes.html#Ratio
 RATIO = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:ratio",
+    "$id": "katsu:mcode:ratio",
     "title": "Ratio",
     "description": "Ratio schema.",
     "type": "object",
@@ -102,7 +102,7 @@ RATIO = {
 
 TIME_OR_PERIOD = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:time_or_period",
+    "$id": "katsu:mcode:time_or_period",
     "title": "Time of Period",
     "description": "Time of Period schema.",
     "type": "object",
@@ -119,7 +119,7 @@ TIME_OR_PERIOD = {
 
 TUMOR_MARKER_DATA_VALUE = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:tumor_marker_data_value",
+    "$id": "katsu:mcode:tumor_marker_data_value",
     "title": "Tumor marker data value",
     "description": "Tumor marker data value schema.",
     "type": "object",
@@ -141,7 +141,7 @@ COMPLEX_ONTOLOGY = customize_schema(
     second_typeof=ONTOLOGY_CLASS,
     first_property="data_value",
     second_property="staging_system",
-    schema_id="chord_metadata_service:complex_ontology_schema",
+    schema_id="katsu:mcode:complex_ontology",
     title="Complex ontology",
     description="Complex object to combine data value and staging system.",
     required=["data_value"]
@@ -152,6 +152,8 @@ COMPLEX_ONTOLOGY = customize_schema(
 
 
 MCODE_GENETIC_SPECIMEN_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:mcode:genetic_specimen",
     "type": "object",
     "properties": {
         "id": {
@@ -167,6 +169,8 @@ MCODE_GENETIC_SPECIMEN_SCHEMA = describe_schema({
 
 
 MCODE_CANCER_GENETIC_VARIANT_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:mcode:cancer_genetic_variant",
     "type": "object",
     "properties": {
         "id": {
@@ -196,6 +200,8 @@ MCODE_CANCER_GENETIC_VARIANT_SCHEMA = describe_schema({
 
 
 MCODE_GENOMIC_REGION_STUDIED_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:mcode:genomic_region_studied",
     "type": "object",
     "properties": {
         "id": {
@@ -221,6 +227,8 @@ MCODE_GENOMIC_REGION_STUDIED_SCHEMA = describe_schema({
 
 
 MCODE_GENOMICS_REPORT_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:mcode:genomics_report",
     "type": "object",
     "properties": {
         "id": {
@@ -247,6 +255,8 @@ MCODE_GENOMICS_REPORT_SCHEMA = describe_schema({
 
 
 MCODE_LABS_VITAL_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:mcode:labs_vital",
     "type": "object",
     "properties": {
         "id": {
@@ -264,6 +274,8 @@ MCODE_LABS_VITAL_SCHEMA = describe_schema({
 
 
 MCODE_TNM_STAGING_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:mcode:tnm_staging",
     "type": "object",
     "properties": {
         "id": {
@@ -298,6 +310,8 @@ MCODE_TNM_STAGING_SCHEMA = describe_schema({
 
 
 MCODE_CANCER_CONDITION_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:mcode:cancer_condition",
     "type": "object",
     "properties": {
         "id": {
@@ -329,6 +343,8 @@ MCODE_CANCER_CONDITION_SCHEMA = describe_schema({
 
 
 MCODE_CANCER_RELATED_PROCEDURE_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:mcode:cancer_related_procedure",
     "type": "object",
     "properties": {
         "id": {
@@ -359,6 +375,8 @@ MCODE_CANCER_RELATED_PROCEDURE_SCHEMA = describe_schema({
 
 
 MCODE_MEDICATION_STATEMENT_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:mcode:medication",
     "type": "object",
     "properties": {
         "id": {
@@ -383,7 +401,7 @@ MCODE_MEDICATION_STATEMENT_SCHEMA = describe_schema({
 
 MCODE_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:mcode_schema",
+    "$id": "katsu:mcode:mcode",
     "title": "Metadata service customized mcode schema",
     "description": "Schema for describe mcode data elements in metadata service.",
     "type": "object",

--- a/chord_metadata_service/mcode/schemas.py
+++ b/chord_metadata_service/mcode/schemas.py
@@ -1,4 +1,8 @@
-from chord_metadata_service.restapi.schema_utils import customize_schema
+from chord_metadata_service.restapi.schema_utils import (
+    customize_schema,
+    tag_schema_with_nested_ids,
+    tag_ids_and_describe,
+)
 from chord_metadata_service.restapi.schemas import ONTOLOGY_CLASS, ONTOLOGY_CLASS_LIST, EXTRA_PROPERTIES_SCHEMA
 from chord_metadata_service.restapi.description_utils import describe_schema
 from chord_metadata_service.patients.schemas import INDIVIDUAL_SCHEMA
@@ -9,7 +13,7 @@ from . import descriptions as d
 # === FHIR datatypes ===
 
 # FHIR Quantity https://www.hl7.org/fhir/datatypes.html#Quantity
-QUANTITY = {
+QUANTITY = tag_schema_with_nested_ids({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:quantity",
     "title": "Quantity schema",
@@ -34,10 +38,10 @@ QUANTITY = {
         }
     },
     "additionalProperties": False
-}
+})
 
 # FHIR CodeableConcept https://www.hl7.org/fhir/datatypes.html#CodeableConcept
-CODEABLE_CONCEPT = {
+CODEABLE_CONCEPT = tag_schema_with_nested_ids({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:codeable_concept",
     "title": "Codeable Concept schema",
@@ -62,10 +66,10 @@ CODEABLE_CONCEPT = {
         }
     },
     "additionalProperties": False
-}
+})
 
 # FHIR Period https://www.hl7.org/fhir/datatypes.html#Period
-PERIOD = {
+PERIOD = tag_schema_with_nested_ids({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:period",
     "title": "Period",
@@ -82,10 +86,10 @@ PERIOD = {
         }
     },
     "additionalProperties": False
-}
+})
 
 # FHIR Ratio https://www.hl7.org/fhir/datatypes.html#Ratio
-RATIO = {
+RATIO = tag_schema_with_nested_ids({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:ratio",
     "title": "Ratio",
@@ -96,11 +100,11 @@ RATIO = {
         "denominator": QUANTITY
     },
     "additionalProperties": False
-}
+})
 
 # === FHIR based mCode elements ===
 
-TIME_OR_PERIOD = {
+TIME_OR_PERIOD = tag_schema_with_nested_ids({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:time_or_period",
     "title": "Time of Period",
@@ -115,9 +119,9 @@ TIME_OR_PERIOD = {
         }
     },
     "additionalProperties": False
-}
+})
 
-TUMOR_MARKER_DATA_VALUE = {
+TUMOR_MARKER_DATA_VALUE = tag_schema_with_nested_ids({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:tumor_marker_data_value",
     "title": "Tumor marker data value",
@@ -133,7 +137,7 @@ TUMOR_MARKER_DATA_VALUE = {
         }
     },
     "additionalProperties": False
-}
+})
 
 # TODO this is definitely should be changed, fhir datatypes are too complex use Ontology_ class
 COMPLEX_ONTOLOGY = customize_schema(
@@ -151,7 +155,7 @@ COMPLEX_ONTOLOGY = customize_schema(
 # =================== Metadata service mCode based schemas ===================
 
 
-MCODE_GENETIC_SPECIMEN_SCHEMA = describe_schema({
+MCODE_GENETIC_SPECIMEN_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:genetic_specimen",
     "type": "object",
@@ -168,7 +172,7 @@ MCODE_GENETIC_SPECIMEN_SCHEMA = describe_schema({
 }, d.GENETIC_SPECIMEN)
 
 
-MCODE_CANCER_GENETIC_VARIANT_SCHEMA = describe_schema({
+MCODE_CANCER_GENETIC_VARIANT_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:cancer_genetic_variant",
     "type": "object",
@@ -199,7 +203,7 @@ MCODE_CANCER_GENETIC_VARIANT_SCHEMA = describe_schema({
 }, d.CANCER_GENETIC_VARIANT)
 
 
-MCODE_GENOMIC_REGION_STUDIED_SCHEMA = describe_schema({
+MCODE_GENOMIC_REGION_STUDIED_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:genomic_region_studied",
     "type": "object",
@@ -226,7 +230,7 @@ MCODE_GENOMIC_REGION_STUDIED_SCHEMA = describe_schema({
 }, d.GENOMIC_REGION_STUDIED)
 
 
-MCODE_GENOMICS_REPORT_SCHEMA = describe_schema({
+MCODE_GENOMICS_REPORT_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:genomics_report",
     "type": "object",
@@ -254,7 +258,7 @@ MCODE_GENOMICS_REPORT_SCHEMA = describe_schema({
 }, d.GENOMICS_REPORT)
 
 
-MCODE_LABS_VITAL_SCHEMA = describe_schema({
+MCODE_LABS_VITAL_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:labs_vital",
     "type": "object",
@@ -273,7 +277,7 @@ MCODE_LABS_VITAL_SCHEMA = describe_schema({
 }, d.LABS_VITAL)
 
 
-MCODE_TNM_STAGING_SCHEMA = describe_schema({
+MCODE_TNM_STAGING_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:tnm_staging",
     "type": "object",
@@ -309,7 +313,7 @@ MCODE_TNM_STAGING_SCHEMA = describe_schema({
 }, d.TNM_STAGING)
 
 
-MCODE_CANCER_CONDITION_SCHEMA = describe_schema({
+MCODE_CANCER_CONDITION_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:cancer_condition",
     "type": "object",
@@ -342,7 +346,7 @@ MCODE_CANCER_CONDITION_SCHEMA = describe_schema({
 }, d.LABS_VITAL)
 
 
-MCODE_CANCER_RELATED_PROCEDURE_SCHEMA = describe_schema({
+MCODE_CANCER_RELATED_PROCEDURE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:cancer_related_procedure",
     "type": "object",
@@ -374,7 +378,7 @@ MCODE_CANCER_RELATED_PROCEDURE_SCHEMA = describe_schema({
 }, d.CANCER_RELATED_PROCEDURE)
 
 
-MCODE_MEDICATION_STATEMENT_SCHEMA = describe_schema({
+MCODE_MEDICATION_STATEMENT_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:medication",
     "type": "object",
@@ -399,7 +403,7 @@ MCODE_MEDICATION_STATEMENT_SCHEMA = describe_schema({
 }, d.MEDICATION_STATEMENT)
 
 
-MCODE_SCHEMA = describe_schema({
+MCODE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:mcode:mcode",
     "title": "Metadata service customized mcode schema",

--- a/chord_metadata_service/patients/schemas.py
+++ b/chord_metadata_service/patients/schemas.py
@@ -16,8 +16,10 @@ COMORBID_CONDITION = customize_schema(
 )
 
 
+INDIVIDUAL_SCHEMA_ID = "katsu:patients:individual"
 INDIVIDUAL_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": INDIVIDUAL_SCHEMA_ID,
     "type": "object",
     "properties": {
         "id": {
@@ -25,6 +27,7 @@ INDIVIDUAL_SCHEMA = describe_schema({
             "description": "Unique researcher-specified identifier for the individual.",
         },
         "alternate_ids": {
+            "$id": f"{INDIVIDUAL_SCHEMA_ID}:alternate_ids",
             "type": "array",
             "items": {
                 "type": "string",
@@ -37,11 +40,13 @@ INDIVIDUAL_SCHEMA = describe_schema({
         },
         "age": AGE_OR_AGE_RANGE,
         "sex": {
+            "$id": f"{INDIVIDUAL_SCHEMA_ID}:sex",
             "type": "string",
             "enum": ["UNKNOWN_SEX", "FEMALE", "MALE", "OTHER_SEX"],
             "description": "An individual's phenotypic sex.",
         },
         "karyotypic_sex": {
+            "$id": f"{INDIVIDUAL_SCHEMA_ID}:karyotypic_sex",
             "type": "string",
             "enum": [
                 "UNKNOWN_KARYOTYPE",

--- a/chord_metadata_service/patients/schemas.py
+++ b/chord_metadata_service/patients/schemas.py
@@ -1,6 +1,5 @@
-from chord_metadata_service.restapi.schema_utils import customize_schema
+from chord_metadata_service.restapi.schema_utils import customize_schema, tag_ids_and_describe
 from chord_metadata_service.restapi.schemas import ONTOLOGY_CLASS, AGE_OR_AGE_RANGE, EXTRA_PROPERTIES_SCHEMA
-from chord_metadata_service.restapi.description_utils import describe_schema
 
 from .descriptions import INDIVIDUAL
 
@@ -16,10 +15,9 @@ COMORBID_CONDITION = customize_schema(
 )
 
 
-INDIVIDUAL_SCHEMA_ID = "katsu:patients:individual"
-INDIVIDUAL_SCHEMA = describe_schema({
+INDIVIDUAL_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": INDIVIDUAL_SCHEMA_ID,
+    "$id": "katsu:patients:individual",
     "type": "object",
     "properties": {
         "id": {
@@ -27,7 +25,6 @@ INDIVIDUAL_SCHEMA = describe_schema({
             "description": "Unique researcher-specified identifier for the individual.",
         },
         "alternate_ids": {
-            "$id": f"{INDIVIDUAL_SCHEMA_ID}:alternate_ids",
             "type": "array",
             "items": {
                 "type": "string",
@@ -40,13 +37,11 @@ INDIVIDUAL_SCHEMA = describe_schema({
         },
         "age": AGE_OR_AGE_RANGE,
         "sex": {
-            "$id": f"{INDIVIDUAL_SCHEMA_ID}:sex",
             "type": "string",
             "enum": ["UNKNOWN_SEX", "FEMALE", "MALE", "OTHER_SEX"],
             "description": "An individual's phenotypic sex.",
         },
         "karyotypic_sex": {
-            "$id": f"{INDIVIDUAL_SCHEMA_ID}:karyotypic_sex",
             "type": "string",
             "enum": [
                 "UNKNOWN_KARYOTYPE",

--- a/chord_metadata_service/phenopackets/schemas.py
+++ b/chord_metadata_service/phenopackets/schemas.py
@@ -33,7 +33,7 @@ __all__ = [
 
 ALLELE_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:allele_schema",
+    "$id": "katsu:phenopackets:allele",
     "title": "Allele schema",
     "description": "Variant allele types",
     "type": "object",
@@ -72,7 +72,7 @@ ALLELE_SCHEMA = describe_schema({
 
 PHENOPACKET_EXTERNAL_REFERENCE_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:external_reference_schema",
+    "$id": "katsu:phenopackets:external_reference",
     "title": "External reference schema",
     "type": "object",
     "properties": {
@@ -89,7 +89,7 @@ PHENOPACKET_EXTERNAL_REFERENCE_SCHEMA = describe_schema({
 
 PHENOPACKET_UPDATE_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:update_schema",
+    "$id": "katsu:phenopackets:update",
     "title": "Updates schema",
     "type": "object",
     "properties": {
@@ -110,8 +110,10 @@ PHENOPACKET_UPDATE_SCHEMA = describe_schema({
 
 
 # noinspection PyProtectedMember
+PHENOPACKET_META_DATA_SCHEMA_ID = "katsu:phenopackets:meta_data"
 PHENOPACKET_META_DATA_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": PHENOPACKET_META_DATA_SCHEMA_ID,
     "type": "object",
     "properties": {
         "created": {
@@ -125,10 +127,12 @@ PHENOPACKET_META_DATA_SCHEMA = describe_schema({
             "type": "string",
         },
         "resources": {
+            "$id": f"{PHENOPACKET_META_DATA_SCHEMA_ID}:resources",
             "type": "array",
             "items": RESOURCE_SCHEMA,
         },
         "updates": {
+            "$id": f"{PHENOPACKET_META_DATA_SCHEMA_ID}:updates",
             "type": "array",
             "items": PHENOPACKET_UPDATE_SCHEMA,
         },
@@ -136,6 +140,7 @@ PHENOPACKET_META_DATA_SCHEMA = describe_schema({
             "type": "string",
         },
         "external_references": {
+            "$id": f"{PHENOPACKET_META_DATA_SCHEMA_ID}:external_references",
             "type": "array",
             "items": PHENOPACKET_EXTERNAL_REFERENCE_SCHEMA
         },
@@ -145,7 +150,7 @@ PHENOPACKET_META_DATA_SCHEMA = describe_schema({
 
 PHENOPACKET_EVIDENCE_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:evidence_schema",
+    "$id": "katsu:phenopackets:evidence",
     "title": "Evidence schema",
     "type": "object",
     "properties": {
@@ -157,6 +162,8 @@ PHENOPACKET_EVIDENCE_SCHEMA = describe_schema({
 }, descriptions.EVIDENCE)
 
 PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:phenopackets:phenotypic_feature",
     "type": "object",
     "properties": {
         "description": {
@@ -180,6 +187,8 @@ PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA = describe_schema({
 
 # TODO: search
 PHENOPACKET_GENE_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:phenopackets:gene",
     "type": "object",
     "properties": {
         "id": {
@@ -201,6 +210,8 @@ PHENOPACKET_GENE_SCHEMA = describe_schema({
 
 
 PHENOPACKET_HTS_FILE_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:phenopackets:hts_file",
     "type": "object",
     "properties": {
         "uri": {
@@ -226,6 +237,8 @@ PHENOPACKET_HTS_FILE_SCHEMA = describe_schema({
 
 # TODO: search??
 PHENOPACKET_VARIANT_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:phenopackets:variant",
     "type": "object",  # TODO
     "properties": {
         "allele": ALLELE_SCHEMA,  # TODO
@@ -235,7 +248,10 @@ PHENOPACKET_VARIANT_SCHEMA = describe_schema({
 }, descriptions.VARIANT)
 
 # noinspection PyProtectedMember
+PHENOPACKET_BIOSAMPLE_SCHEMA_ID = "katsu:phenopackets:biosample"
 PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:phenopackets:biosample",
     "type": "object",
     "properties": {
         "id": {
@@ -249,6 +265,7 @@ PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
         },
         "sampled_tissue": ONTOLOGY_CLASS,
         "phenotypic_features": {
+            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:phenotypic_features",
             "type": "array",
             "items": PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA,
         },
@@ -258,10 +275,12 @@ PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
         "tumor_progression": ONTOLOGY_CLASS,
         "tumor_grade": ONTOLOGY_CLASS,  # TODO: Is this a list?
         "diagnostic_markers": {
+            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:diagnostic_markers",
             "type": "array",
             "items": ONTOLOGY_CLASS,
         },
         "procedure": {
+            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:procedure",
             "type": "object",
             "properties": {
                 "code": ONTOLOGY_CLASS,
@@ -270,10 +289,12 @@ PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
             "required": ["code"],
         },
         "hts_files": {
+            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:hts_files",
             "type": "array",
             "items": PHENOPACKET_HTS_FILE_SCHEMA
         },
         "variants": {
+            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:variants",
             "type": "array",
             "items": PHENOPACKET_VARIANT_SCHEMA
         },
@@ -288,7 +309,7 @@ PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
 
 PHENOPACKET_DISEASE_ONSET_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:disease_onset_schema",
+    "$id": "katsu:phenopackets:disease_onset",
     "title": "Onset age",
     "description": "Schema for the age of the onset of the disease.",
     "type": "object",
@@ -299,19 +320,22 @@ PHENOPACKET_DISEASE_ONSET_SCHEMA = {
     ]
 }
 
+PHENOPACKET_DISEASE_SCHEMA_ID = "katsu:phenopackets:disease"
 PHENOPACKET_DISEASE_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:disease_schema",
+    "$id": PHENOPACKET_DISEASE_SCHEMA_ID,
     "title": "Disease schema",
     "type": "object",
     "properties": {
         "term": ONTOLOGY_CLASS,
         "onset": PHENOPACKET_DISEASE_ONSET_SCHEMA,
         "disease_stage": {
+            "$id": f"{PHENOPACKET_DISEASE_SCHEMA_ID}:disease_stage",
             "type": "array",
             "items": ONTOLOGY_CLASS,
         },
         "tnm_finding": {
+            "$id": f"{PHENOPACKET_DISEASE_SCHEMA_ID}:tnm_finding",
             "type": "array",
             "items": ONTOLOGY_CLASS,
         },
@@ -322,9 +346,10 @@ PHENOPACKET_DISEASE_SCHEMA = describe_schema({
 
 # Deduplicate with other phenopacket representations
 # noinspection PyProtectedMember
+PHENOPACKET_SCHEMA_ID = "katsu:phenopackets:phenopacket"
 PHENOPACKET_SCHEMA = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:phenopacket_schema",
+    "$id": PHENOPACKET_SCHEMA_ID,
     "title": "Phenopacket schema",
     "description": "Schema for metadata service datasets",
     "type": "object",
@@ -334,26 +359,32 @@ PHENOPACKET_SCHEMA = describe_schema({
         },
         "subject": INDIVIDUAL_SCHEMA,
         "phenotypic_features": {
+            "$id": f"{PHENOPACKET_SCHEMA_ID}:phenotypic_features",
             "type": "array",
             "items": PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA
         },
         "biosamples": {
+            "$id": f"{PHENOPACKET_SCHEMA_ID}:biosamples",
             "type": "array",
             "items": PHENOPACKET_BIOSAMPLE_SCHEMA
         },
         "genes": {
+            "$id": f"{PHENOPACKET_SCHEMA_ID}:genes",
             "type": "array",
             "items": PHENOPACKET_GENE_SCHEMA
         },
         "variants": {
+            "$id": f"{PHENOPACKET_SCHEMA_ID}:variants",
             "type": "array",
             "items": PHENOPACKET_VARIANT_SCHEMA
         },
         "diseases": {  # TODO: Too sensitive for search?
+            "$id": f"{PHENOPACKET_SCHEMA_ID}:diseases",
             "type": "array",
             "items": PHENOPACKET_DISEASE_SCHEMA,
         },  # TODO
         "hts_files": {
+            "$id": f"{PHENOPACKET_SCHEMA_ID}:hts_files",
             "type": "array",
             "items": PHENOPACKET_HTS_FILE_SCHEMA  # TODO
         },

--- a/chord_metadata_service/phenopackets/schemas.py
+++ b/chord_metadata_service/phenopackets/schemas.py
@@ -2,7 +2,6 @@
 
 from chord_metadata_service.patients.schemas import INDIVIDUAL_SCHEMA
 from chord_metadata_service.resources.schemas import RESOURCE_SCHEMA
-from chord_metadata_service.restapi.description_utils import describe_schema
 from chord_metadata_service.restapi.schemas import (
     AGE,
     AGE_RANGE,
@@ -10,6 +9,7 @@ from chord_metadata_service.restapi.schemas import (
     EXTRA_PROPERTIES_SCHEMA,
     ONTOLOGY_CLASS,
 )
+from chord_metadata_service.restapi.schema_utils import tag_ids_and_describe
 
 from . import descriptions
 
@@ -31,7 +31,7 @@ __all__ = [
 ]
 
 
-ALLELE_SCHEMA = describe_schema({
+ALLELE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:phenopackets:allele",
     "title": "Allele schema",
@@ -70,7 +70,7 @@ ALLELE_SCHEMA = describe_schema({
 }, descriptions.ALLELE)
 
 
-PHENOPACKET_EXTERNAL_REFERENCE_SCHEMA = describe_schema({
+PHENOPACKET_EXTERNAL_REFERENCE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:phenopackets:external_reference",
     "title": "External reference schema",
@@ -87,7 +87,7 @@ PHENOPACKET_EXTERNAL_REFERENCE_SCHEMA = describe_schema({
 }, descriptions.EXTERNAL_REFERENCE)
 
 
-PHENOPACKET_UPDATE_SCHEMA = describe_schema({
+PHENOPACKET_UPDATE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:phenopackets:update",
     "title": "Updates schema",
@@ -110,10 +110,9 @@ PHENOPACKET_UPDATE_SCHEMA = describe_schema({
 
 
 # noinspection PyProtectedMember
-PHENOPACKET_META_DATA_SCHEMA_ID = "katsu:phenopackets:meta_data"
-PHENOPACKET_META_DATA_SCHEMA = describe_schema({
+PHENOPACKET_META_DATA_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": PHENOPACKET_META_DATA_SCHEMA_ID,
+    "$id": "katsu:phenopackets:meta_data",
     "type": "object",
     "properties": {
         "created": {
@@ -127,12 +126,10 @@ PHENOPACKET_META_DATA_SCHEMA = describe_schema({
             "type": "string",
         },
         "resources": {
-            "$id": f"{PHENOPACKET_META_DATA_SCHEMA_ID}:resources",
             "type": "array",
             "items": RESOURCE_SCHEMA,
         },
         "updates": {
-            "$id": f"{PHENOPACKET_META_DATA_SCHEMA_ID}:updates",
             "type": "array",
             "items": PHENOPACKET_UPDATE_SCHEMA,
         },
@@ -140,7 +137,6 @@ PHENOPACKET_META_DATA_SCHEMA = describe_schema({
             "type": "string",
         },
         "external_references": {
-            "$id": f"{PHENOPACKET_META_DATA_SCHEMA_ID}:external_references",
             "type": "array",
             "items": PHENOPACKET_EXTERNAL_REFERENCE_SCHEMA
         },
@@ -148,7 +144,7 @@ PHENOPACKET_META_DATA_SCHEMA = describe_schema({
     },
 }, descriptions.META_DATA)
 
-PHENOPACKET_EVIDENCE_SCHEMA = describe_schema({
+PHENOPACKET_EVIDENCE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:phenopackets:evidence",
     "title": "Evidence schema",
@@ -161,7 +157,7 @@ PHENOPACKET_EVIDENCE_SCHEMA = describe_schema({
     "required": ["evidence_code"],
 }, descriptions.EVIDENCE)
 
-PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA = describe_schema({
+PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:phenopackets:phenotypic_feature",
     "type": "object",
@@ -186,7 +182,7 @@ PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA = describe_schema({
 
 
 # TODO: search
-PHENOPACKET_GENE_SCHEMA = describe_schema({
+PHENOPACKET_GENE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:phenopackets:gene",
     "type": "object",
@@ -209,7 +205,7 @@ PHENOPACKET_GENE_SCHEMA = describe_schema({
 }, descriptions.GENE)
 
 
-PHENOPACKET_HTS_FILE_SCHEMA = describe_schema({
+PHENOPACKET_HTS_FILE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:phenopackets:hts_file",
     "type": "object",
@@ -236,7 +232,7 @@ PHENOPACKET_HTS_FILE_SCHEMA = describe_schema({
 
 
 # TODO: search??
-PHENOPACKET_VARIANT_SCHEMA = describe_schema({
+PHENOPACKET_VARIANT_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:phenopackets:variant",
     "type": "object",  # TODO
@@ -248,8 +244,7 @@ PHENOPACKET_VARIANT_SCHEMA = describe_schema({
 }, descriptions.VARIANT)
 
 # noinspection PyProtectedMember
-PHENOPACKET_BIOSAMPLE_SCHEMA_ID = "katsu:phenopackets:biosample"
-PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
+PHENOPACKET_BIOSAMPLE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:phenopackets:biosample",
     "type": "object",
@@ -265,7 +260,6 @@ PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
         },
         "sampled_tissue": ONTOLOGY_CLASS,
         "phenotypic_features": {
-            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:phenotypic_features",
             "type": "array",
             "items": PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA,
         },
@@ -275,12 +269,10 @@ PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
         "tumor_progression": ONTOLOGY_CLASS,
         "tumor_grade": ONTOLOGY_CLASS,  # TODO: Is this a list?
         "diagnostic_markers": {
-            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:diagnostic_markers",
             "type": "array",
             "items": ONTOLOGY_CLASS,
         },
         "procedure": {
-            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:procedure",
             "type": "object",
             "properties": {
                 "code": ONTOLOGY_CLASS,
@@ -289,12 +281,10 @@ PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
             "required": ["code"],
         },
         "hts_files": {
-            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:hts_files",
             "type": "array",
             "items": PHENOPACKET_HTS_FILE_SCHEMA
         },
         "variants": {
-            "$id": f"{PHENOPACKET_BIOSAMPLE_SCHEMA_ID}:variants",
             "type": "array",
             "items": PHENOPACKET_VARIANT_SCHEMA
         },
@@ -320,22 +310,19 @@ PHENOPACKET_DISEASE_ONSET_SCHEMA = {
     ]
 }
 
-PHENOPACKET_DISEASE_SCHEMA_ID = "katsu:phenopackets:disease"
-PHENOPACKET_DISEASE_SCHEMA = describe_schema({
+PHENOPACKET_DISEASE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": PHENOPACKET_DISEASE_SCHEMA_ID,
+    "$id": "katsu:phenopackets:disease",
     "title": "Disease schema",
     "type": "object",
     "properties": {
         "term": ONTOLOGY_CLASS,
         "onset": PHENOPACKET_DISEASE_ONSET_SCHEMA,
         "disease_stage": {
-            "$id": f"{PHENOPACKET_DISEASE_SCHEMA_ID}:disease_stage",
             "type": "array",
             "items": ONTOLOGY_CLASS,
         },
         "tnm_finding": {
-            "$id": f"{PHENOPACKET_DISEASE_SCHEMA_ID}:tnm_finding",
             "type": "array",
             "items": ONTOLOGY_CLASS,
         },
@@ -346,10 +333,9 @@ PHENOPACKET_DISEASE_SCHEMA = describe_schema({
 
 # Deduplicate with other phenopacket representations
 # noinspection PyProtectedMember
-PHENOPACKET_SCHEMA_ID = "katsu:phenopackets:phenopacket"
-PHENOPACKET_SCHEMA = describe_schema({
+PHENOPACKET_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": PHENOPACKET_SCHEMA_ID,
+    "$id": "katsu:phenopackets:phenopacket",
     "title": "Phenopacket schema",
     "description": "Schema for metadata service datasets",
     "type": "object",
@@ -359,32 +345,26 @@ PHENOPACKET_SCHEMA = describe_schema({
         },
         "subject": INDIVIDUAL_SCHEMA,
         "phenotypic_features": {
-            "$id": f"{PHENOPACKET_SCHEMA_ID}:phenotypic_features",
             "type": "array",
             "items": PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA
         },
         "biosamples": {
-            "$id": f"{PHENOPACKET_SCHEMA_ID}:biosamples",
             "type": "array",
             "items": PHENOPACKET_BIOSAMPLE_SCHEMA
         },
         "genes": {
-            "$id": f"{PHENOPACKET_SCHEMA_ID}:genes",
             "type": "array",
             "items": PHENOPACKET_GENE_SCHEMA
         },
         "variants": {
-            "$id": f"{PHENOPACKET_SCHEMA_ID}:variants",
             "type": "array",
             "items": PHENOPACKET_VARIANT_SCHEMA
         },
         "diseases": {  # TODO: Too sensitive for search?
-            "$id": f"{PHENOPACKET_SCHEMA_ID}:diseases",
             "type": "array",
             "items": PHENOPACKET_DISEASE_SCHEMA,
         },  # TODO
         "hts_files": {
-            "$id": f"{PHENOPACKET_SCHEMA_ID}:hts_files",
             "type": "array",
             "items": PHENOPACKET_HTS_FILE_SCHEMA  # TODO
         },

--- a/chord_metadata_service/resources/schemas.py
+++ b/chord_metadata_service/resources/schemas.py
@@ -1,5 +1,5 @@
-from chord_metadata_service.restapi.description_utils import describe_schema
 from chord_metadata_service.restapi.schemas import EXTRA_PROPERTIES_SCHEMA
+from chord_metadata_service.restapi.schema_utils import tag_ids_and_describe
 
 from . import descriptions
 
@@ -7,8 +7,9 @@ from . import descriptions
 __all__ = ["RESOURCE_SCHEMA"]
 
 
-RESOURCE_SCHEMA = describe_schema({
+RESOURCE_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:resources:resource",
     "type": "object",  # TODO
     "properties": {
         "id": {

--- a/chord_metadata_service/restapi/schemas.py
+++ b/chord_metadata_service/restapi/schemas.py
@@ -1,5 +1,6 @@
 from . import descriptions
-from .description_utils import describe_schema, EXTRA_PROPERTIES, ONTOLOGY_CLASS as ONTOLOGY_CLASS_DESC
+from .description_utils import EXTRA_PROPERTIES, ONTOLOGY_CLASS as ONTOLOGY_CLASS_DESC
+from .schema_utils import tag_ids_and_describe, tag_schema_with_nested_ids
 
 # Individual schemas for validation of JSONField values
 
@@ -20,7 +21,7 @@ __all__ = [
 # ======================== Phenopackets based schemas =========================
 
 
-ONTOLOGY_CLASS = describe_schema({
+ONTOLOGY_CLASS = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:common:ontology_class",
     "title": "Ontology class schema",
@@ -55,20 +56,20 @@ KEY_VALUE_OBJECT = {
     "additionalProperties": False
 }
 
-EXTRA_PROPERTIES_SCHEMA = describe_schema({
+EXTRA_PROPERTIES_SCHEMA = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:common:extra_properties",
     "type": "object"
 }, EXTRA_PROPERTIES)
 
 
-AGE_STRING = describe_schema({
+AGE_STRING = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:common:age_string",
     "type": "string"
 }, descriptions.AGE)
 
-AGE = describe_schema({
+AGE = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:common:age",
     "title": "Age schema",
@@ -81,7 +82,7 @@ AGE = describe_schema({
 }, descriptions.AGE_NESTED)
 
 
-AGE_RANGE = describe_schema({
+AGE_RANGE = tag_ids_and_describe({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:common:age_range",
     "title": "Age range schema",
@@ -126,7 +127,7 @@ DISEASE_ONSET = {
 # The schema used to validate FHIR data for ingestion
 
 
-FHIR_BUNDLE_SCHEMA = {
+FHIR_BUNDLE_SCHEMA = tag_schema_with_nested_ids({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "katsu:common:fhir_bundle",
     "description": "FHIR Bundle schema",
@@ -151,4 +152,4 @@ FHIR_BUNDLE_SCHEMA = {
     },
     "additionalProperties": True,
     "required": ["resourceType", "entry"]
-}
+})

--- a/chord_metadata_service/restapi/schemas.py
+++ b/chord_metadata_service/restapi/schemas.py
@@ -22,7 +22,7 @@ __all__ = [
 
 ONTOLOGY_CLASS = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:ontology_class_schema",
+    "$id": "katsu:common:ontology_class",
     "title": "Ontology class schema",
     "type": "object",
     "properties": {
@@ -35,7 +35,7 @@ ONTOLOGY_CLASS = describe_schema({
 
 ONTOLOGY_CLASS_LIST = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:ontology_class_list_schema",
+    "$id": "katsu:common:ontology_class_list",
     "title": "Ontology class list",
     "description": "Ontology class list",
     "type": "array",
@@ -45,7 +45,7 @@ ONTOLOGY_CLASS_LIST = {
 
 KEY_VALUE_OBJECT = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:key_value_object_schema",
+    "$id": "katsu:common:key_value_object",
     "title": "Key-value object",
     "description": "The schema represents a key-value object.",
     "type": "object",
@@ -56,15 +56,21 @@ KEY_VALUE_OBJECT = {
 }
 
 EXTRA_PROPERTIES_SCHEMA = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:common:extra_properties",
     "type": "object"
 }, EXTRA_PROPERTIES)
 
 
-AGE_STRING = describe_schema({"type": "string"}, descriptions.AGE)
+AGE_STRING = describe_schema({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:common:age_string",
+    "type": "string"
+}, descriptions.AGE)
 
 AGE = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:age_schema",
+    "$id": "katsu:common:age",
     "title": "Age schema",
     "type": "object",
     "properties": {
@@ -77,7 +83,7 @@ AGE = describe_schema({
 
 AGE_RANGE = describe_schema({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:age_range_schema",
+    "$id": "katsu:common:age_range",
     "title": "Age range schema",
     "type": "object",
     "properties": {
@@ -91,7 +97,7 @@ AGE_RANGE = describe_schema({
 
 AGE_OR_AGE_RANGE = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:age_or_age_range_schema",
+    "$id": "katsu:common:age_or_age_range",
     "title": "Age schema",
     "description": "An age object describing the age of the individual at the time of collection of biospecimens or "
                    "phenotypic observations.",
@@ -104,7 +110,7 @@ AGE_OR_AGE_RANGE = {
 
 DISEASE_ONSET = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "chord_metadata_service:disease_onset_schema",
+    "$id": "katsu:common:disease_onset",
     "title": "Onset age",
     "description": "Schema for the age of the onset of the disease.",
     "type": "object",
@@ -121,8 +127,8 @@ DISEASE_ONSET = {
 
 
 FHIR_BUNDLE_SCHEMA = {
-    "$id": "chord_metadata_service_fhir_bundle_schema",
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "katsu:common:fhir_bundle",
     "description": "FHIR Bundle schema",
     "type": "object",
     "properties": {

--- a/chord_metadata_service/restapi/tests/test_schema_utils.py
+++ b/chord_metadata_service/restapi/tests/test_schema_utils.py
@@ -49,3 +49,7 @@ class TestSchemaMerge(TestCase):
         self.assertEqual(tagged["properties"]["key1"]["items"]["$id"], "schema1:key1:item")
         self.assertEqual(tagged["properties"]["key2"]["$id"], "schema1:key2")
         self.assertEqual(tagged["properties"]["key2"]["properties"]["key1"]["$id"], "schema1:key2:key1")
+
+    def test_id_raises(self):
+        with self.assertRaises(ValueError):
+            tag_schema_with_nested_ids({"type": "object", "properties": {"a": {"type": "string"}}})

--- a/chord_metadata_service/restapi/tests/test_schema_utils.py
+++ b/chord_metadata_service/restapi/tests/test_schema_utils.py
@@ -1,5 +1,27 @@
 from django.test import TestCase
-from ..schema_utils import merge_schema_dictionaries
+from ..schema_utils import merge_schema_dictionaries, tag_schema_with_nested_ids
+
+
+SCHEMA_1 = {
+    "$id": "schema1",
+    "type": "object",
+    "properties": {
+        "key1": {
+            "type": "array",
+            "items": {
+                "type": "string",
+            }
+        },
+        "key2": {
+            "type": "object",
+            "properties": {
+                "key1": {
+                    "type": "string",
+                }
+            }
+        },
+    },
+}
 
 
 class TestSchemaMerge(TestCase):
@@ -19,3 +41,11 @@ class TestSchemaMerge(TestCase):
                 {"a": {"b": 1}, "c": {"d": {"e": 1}, "f": 5}},
                 {"c": {"d": {"g": 8}}}),
             {"a": {"b": 1}, "c": {"d": {"e": 1, "g": 8}, "f": 5}})
+
+    def test_id_tag(self):
+        tagged = tag_schema_with_nested_ids(SCHEMA_1)
+
+        self.assertEqual(tagged["properties"]["key1"]["$id"], "schema1:key1")
+        self.assertEqual(tagged["properties"]["key1"]["items"]["$id"], "schema1:key1:item")
+        self.assertEqual(tagged["properties"]["key2"]["$id"], "schema1:key2")
+        self.assertEqual(tagged["properties"]["key2"]["properties"]["key1"]["$id"], "schema1:key2:key1")


### PR DESCRIPTION
This should hopefully make debugging search in prod a bit more straightforward - it adds nested `$id` fields to all sub-schemas, even stuff like string fields, to not get `N/A` from the search errors and to generally give more precision with schema failures.

It also renames IDs into a consistent and slightly shorter `katsu:[app name]:[schema name]` format, and fields are tagged like `katsu:[app name]:[schema name]:prop_name` or `katsu:[app name]:[schema name]:item:array_obj_prop`.