### PR TITLE
Remove if condition from experiment result schemas

### DIFF
--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -41,19 +41,6 @@ EXPERIMENT_RESULT_SCHEMA = tag_ids_and_describe({
             "type": "string"
         },
         "extra_properties": KEY_VALUE_OBJECT,
-    },
-    "if": {
-        "properties": {"data_output_type": {"const": ["Raw data"]}}
-    },
-    "then": {
-        "properties": {"file_format": {"enum": ["SAM", "BAM", "CRAM", "BAI", "CRAI", "VCF", "BCF", "GVCF",
-                                                "BigWig", "BigBed", "FASTA", "FASTQ", "TAB", "SRA", "SRF",
-                                                "SFF", "GFF", "TABIX", "UNKNOWN", "OTHER"]}}
-    },
-    "else": {
-        "properties": {"file_format": {"enum": ["SAM", "BAM", "CRAM", "BAI", "CRAI", "BCF", "GVCF",
-                                                "BigWig", "BigBed", "FASTA", "FASTQ", "TAB", "SRA", "SRF",
-                                                "SFF", "GFF", "TABIX", "UNKNOWN", "OTHER"]}}
     }
 }, EXPERIMENT_RESULT)
 

--- a/chord_metadata_service/package.cfg
+++ b/chord_metadata_service/package.cfg
@@ -1,4 +1,4 @@
 [package]
 name = katsu
-version = 2.2.4
+version = 2.2.5
 authors = Ksenia Zaytseva, David Lougheed, Simon Chénard, Romain Grégoire


### PR DESCRIPTION
Removes the if/then/else condition from experiment result schema, this condition needs more clarification about what are derived and what are the raw data formats since we see some of them used in both categories.