### PR TITLE
Search changes and new commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
      * [Branching](#branching)
      * [Tests](#tests)
      * [Terminal Commands](#terminal-commands)
-        * [Bento Commands](#bento-commands)
+        * [Project/Dataset/Table/Ingestion Commands](#projectdatasettableingestion-commands)
         * [Patient Commands](#patient-commands)
         * [Phenopacket Commands](#phenopacket-commands)
      * [Accessing the Django Shell from inside a Bento Container](#accessing-the-django-shell-from-inside-a-bento-container)
@@ -33,7 +33,7 @@ under the BSD 3-clause license.
 
 ## Funding
 
-Katsu Metadata service development is funded by CANARIE under the CHORD project.
+CANARIE funded initial development of the Katsu Metadata service under the CHORD project.
 
 ## Architecture
 
@@ -128,8 +128,9 @@ for a standalone instance of this server, so it can be swapped out.
 By default, `katsu` uses the CHORD permission system, which
 functions as follows:
 
-  * URLs under the `/private` namespace are assumed to be protected by an
-    **out-of-band** mechanism such as a properly-configured reverse proxy.
+  * The service assumes that an **out-of-band** mechanism (such as a 
+    properly-configured reverse proxy) protects URLs under the `/private` 
+    namespace.
   * Requests with the headers `X-User` and `X-User-Role` can be authenticated
     via a Django Remote User-type system, with `X-User-Role: owner` giving
     access to restricted endpoints and `X-User-Role: user` giving less trusted,
@@ -159,7 +160,8 @@ out and tagged from the tagged major/minor release in `master`.
 
 ### Tests
 
-Tests are located in tests directory in an individual app folder.
+Each individual Django app folder within the project contains relevant tests
+(if applicable) in the `tests` directory.
 
 Run all tests and linting checks for the whole project:
 
@@ -205,6 +207,15 @@ output including the new ID for the project, which is needed when creating
 datasets under the project.
 
 ```
+$ ./manage.py list_projects
+identifier         title  description       created                           updated
+-----------------  -----  ----------------  --------------------------------  --------------------------------
+756a4530-59b7-...  test   test description  2021-01-07 22:36:05.460537+00:00  2021-01-07 22:36:05.460570+00:00
+```
+
+Lists all projects currently in the system.
+
+```
 $ ./manage.py create_dataset \
   "dataset title" \
   "dataset description" \
@@ -222,6 +233,15 @@ Creates a new dataset under the project specified (with its ID), with
 corresponding title, description, contact information, and data use conditions.
 
 ```
+$ ./manage.py list_project_datasets 756a4530-59b7-4d47-a04a-c6ee5aa52565
+identifier                            title          description
+------------------------------------  -------------  -------------------
+2a8f8e68-a34f-4d31-952a-22f362ebee9e  dataset title  dataset description
+```
+
+Lists all datasets under a specified project.
+
+```
 $ ./manage.py create_table \
   "table name" \
   phenopacket \
@@ -236,6 +256,15 @@ Table created: table name (ID: 0d63bafe-5d76-46be-82e6-3a07994bac2e, Type: pheno
 
 Creates a new data table under the dataset specified (with its ID), with a 
 corresponding name and data type (either `phenopacket` or `experiment`.)
+
+```
+$ ./manage.py list_dataset_tables 2a8f8e68-a34f-4d31-952a-22f362ebee9e
+ownership_record__table_id  name        data_type    created                           updated
+--------------------------  ----------  -----------  --------------------------------  --------------------------------
+0d63bafe-5d76-46be-82e6...  table name  phenopacket  2021-01-08 15:09:52.346934+00:00  2021-01-08 15:09:52.346966+00:00
+```
+
+Lists all tables under a specified dataset.
 
 ```"
 $ ./manage.py ingest \

--- a/chord_metadata_service/chord/management/commands/list_dataset_tables.py
+++ b/chord_metadata_service/chord/management/commands/list_dataset_tables.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+from tabulate import tabulate
+
+from chord_metadata_service.chord.models import Dataset, Table
+
+
+class Command(BaseCommand):
+    help = """
+        Lists all tables that belong to a particular dataset.
+        Arguments: "dataset-id"
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("dataset", action="store", type=str, help="Dataset identifier to list tables of")
+
+    def handle(self, *args, **options):
+        print(tabulate(
+            Table.objects.select_related("ownership_record").filter(
+                ownership_record__dataset=Dataset.objects.get(identifier=options["dataset"].strip())
+            ).values("ownership_record__table_id", "name", "data_type", "created", "updated"), headers="keys"))

--- a/chord_metadata_service/chord/management/commands/list_project_datasets.py
+++ b/chord_metadata_service/chord/management/commands/list_project_datasets.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+from tabulate import tabulate
+
+from chord_metadata_service.chord.models import Project, Dataset
+
+
+class Command(BaseCommand):
+    help = """
+        Lists all datasets that belong to a particular project.
+        Arguments: "project-id"
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("project", action="store", type=str, help="Project identifier to list datasets of")
+
+    def handle(self, *args, **options):
+        print(tabulate([
+            {k: str(v)[:100] for k, v in d.items() if k in {"identifier", "title", "description"}} for d in
+            Dataset.objects.filter(project=Project.objects.get(identifier=options["project"].strip())).values()
+        ], headers="keys"))

--- a/chord_metadata_service/chord/management/commands/list_projects.py
+++ b/chord_metadata_service/chord/management/commands/list_projects.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+from tabulate import tabulate
+
+from chord_metadata_service.chord.models import Project
+
+
+class Command(BaseCommand):
+    help = """
+        Creates a Katsu/Bento project in the database.
+        Arguments: "title" "description"
+    """
+
+    def handle(self, *args, **options):
+        print(tabulate(Project.objects.values(), headers="keys"))

--- a/chord_metadata_service/chord/management/commands/list_projects.py
+++ b/chord_metadata_service/chord/management/commands/list_projects.py
@@ -6,8 +6,7 @@ from chord_metadata_service.chord.models import Project
 
 class Command(BaseCommand):
     help = """
-        Creates a Katsu/Bento project in the database.
-        Arguments: "title" "description"
+        Lists all projects in the database.
     """
 
     def handle(self, *args, **options):

--- a/chord_metadata_service/chord/management/commands/search_table.py
+++ b/chord_metadata_service/chord/management/commands/search_table.py
@@ -1,0 +1,23 @@
+import json
+from django.core.management.base import BaseCommand
+from datetime import datetime
+from tabulate import tabulate
+
+from chord_metadata_service.chord.views_search import chord_table_search
+
+
+class Command(BaseCommand):
+    help = """
+        Executes a bento-lib-query-style search on a table.
+        Arguments: "table-id" "query"
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("table", action="store", type=str, help="Table to search on.")
+        parser.add_argument("query", action="store", type=str, help="Query to execute.")
+
+    def handle(self, *args, **options):
+        start = datetime.now()
+        query = json.loads(options["query"].strip())
+        print("Executing query:", query)
+        print(tabulate(chord_table_search(query, options["table"].strip(), start, internal=True)[0]))

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -451,32 +451,32 @@ class SearchTest(APITestCase):
     def test_fhir_search(self, mocked_es):
         mocked_es.search.return_value = SEARCH_SUCCESS
         # Valid search with result
-        r = self.client.post(reverse("fhir-search"), data=json.dumps({
-            "data_type": DATA_TYPE_PHENOPACKET,
-            "query": TEST_FHIR_SEARCH_QUERY
-        }), content_type="application/json")
+        for method in POST_GET:
+            r = self._search_call("fhir-search", data={
+                "query": TEST_FHIR_SEARCH_QUERY
+            }, method=method)
 
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
 
-        self.assertEqual(len(c["results"]), 1)
-        self.assertDictEqual(c["results"][0], {
-            "id": str(self.table.identifier),
-            "data_type": DATA_TYPE_PHENOPACKET
-        })
+            self.assertEqual(len(c["results"]), 1)
+            self.assertDictEqual(c["results"][0], {
+                "id": str(self.table.identifier),
+                "data_type": DATA_TYPE_PHENOPACKET
+            })
 
     @patch('chord_metadata_service.chord.views_search.es')
     def test_private_fhir_search(self, mocked_es):
         mocked_es.search.return_value = SEARCH_SUCCESS
         # Valid search with result
-        r = self.client.post(reverse("fhir-private-search"), data=json.dumps({
-            "data_type": DATA_TYPE_PHENOPACKET,
-            "query": TEST_FHIR_SEARCH_QUERY
-        }), content_type="application/json")
+        for method in POST_GET:
+            r = self._search_call("fhir-private-search", data={
+                "query": TEST_FHIR_SEARCH_QUERY
+            }, method=method)
 
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
 
-        self.assertIn(str(self.table.identifier), c["results"])
-        self.assertEqual(c["results"][str(self.table.identifier)]["data_type"], DATA_TYPE_PHENOPACKET)
-        self.assertEqual(self.phenopacket.id, c["results"][str(self.table.identifier)]["matches"][0]["id"])
+            self.assertIn(str(self.table.identifier), c["results"])
+            self.assertEqual(c["results"][str(self.table.identifier)]["data_type"], DATA_TYPE_PHENOPACKET)
+            self.assertEqual(self.phenopacket.id, c["results"][str(self.table.identifier)]["matches"][0]["id"])

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -41,6 +41,8 @@ from .constants import (
 from ..models import Project, Dataset, TableOwnership, Table
 from ..data_types import DATA_TYPE_EXPERIMENT, DATA_TYPE_MCODEPACKET, DATA_TYPE_PHENOPACKET, DATA_TYPES
 
+POST_GET = ("POST", "GET")
+
 
 class DataTypeTest(APITestCase):
     def test_data_type_list(self):
@@ -172,237 +174,278 @@ class SearchTest(APITestCase):
             biosample=self.biosample_1, instrument=self.instrument, table=self.t_exp))
         self.experiment.experiment_results.set([self.experiment_result])
 
+    def _search_call(self, endpoint, args=None, data=None, method="GET"):
+        args = args or []
+
+        if method == "POST":
+            data = json.dumps(data)
+        else:
+            data = data if data is None or "query" not in data else {
+                **data,
+                "query": json.dumps(data["query"]),
+            }
+
+        return (self.client.post if method == "POST" else self.client.get)(
+            reverse(endpoint, args=args),
+            data=data,
+            **({"content_type": "application/json"} if method == "POST" else {}))
+
     def test_common_search_1(self):
         # No body
-        r = self.client.post(reverse("search"))
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        for method in POST_GET:
+            r = self._search_call("search", method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_common_search_2(self):
         # No data type
-        r = self.client.post(reverse("search"), data=json.dumps({"query": TEST_SEARCH_QUERY_1}),
-                             content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        for method in POST_GET:
+            r = self._search_call("search", data={"query": TEST_SEARCH_QUERY_1}, method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_common_search_3(self):
         # No query
-        r = self.client.post(reverse("search"), data=json.dumps({"data_type": DATA_TYPE_PHENOPACKET}),
-                             content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        for method in POST_GET:
+            r = self._search_call("search", data={"data_type": DATA_TYPE_PHENOPACKET}, method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_common_search_4(self):
         # Bad data type
-        r = self.client.post(reverse("search"), data=json.dumps({
-            "data_type": "bad_data_type",
-            "query": TEST_SEARCH_QUERY_1
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        for method in POST_GET:
+            r = self._search_call("search", data={
+                "data_type": "bad_data_type",
+                "query": TEST_SEARCH_QUERY_1,
+            }, method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_common_search_5(self):
         # Bad syntax for query
-        r = self.client.post(reverse("search"), data=json.dumps({
-            "data_type": DATA_TYPE_PHENOPACKET,
-            "query": ["hello", "world"]
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        for method in POST_GET:
+            r = self._search_call("search", data={
+                "data_type": DATA_TYPE_PHENOPACKET,
+                "query": ["hello", "world"]
+            }, method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_search_with_result(self):
         # Valid search with result
-        r = self.client.post(reverse("search"), data=json.dumps({
-            "data_type": DATA_TYPE_PHENOPACKET,
-            "query": TEST_SEARCH_QUERY_1
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(len(c["results"]), 1)
-        self.assertDictEqual(c["results"][0], {
-            "id": str(self.table.identifier),
-            "data_type": DATA_TYPE_PHENOPACKET
-        })
+        for method in POST_GET:
+            r = self._search_call("search", data={
+                "data_type": DATA_TYPE_PHENOPACKET,
+                "query": TEST_SEARCH_QUERY_1
+            }, method=method)
+            print(r, r.json())
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+
+            c = r.json()
+
+            self.assertEqual(len(c["results"]), 1)
+            self.assertDictEqual(c["results"][0], {
+                "id": str(self.table.identifier),
+                "data_type": DATA_TYPE_PHENOPACKET
+            })
 
     def test_search_without_result(self):
         # Valid search without result
-        r = self.client.post(reverse("search"), data=json.dumps({
-            "data_type": DATA_TYPE_PHENOPACKET,
-            "query": TEST_SEARCH_QUERY_2
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(len(c["results"]), 0)
+        for method in POST_GET:
+            r = self._search_call("search", data={
+                "data_type": DATA_TYPE_PHENOPACKET,
+                "query": TEST_SEARCH_QUERY_2
+            }, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 0)
 
     def test_private_search(self):
         # Valid search with result
-        r = self.client.post(reverse("private-search"), data=json.dumps({
-            "data_type": DATA_TYPE_PHENOPACKET,
-            "query": TEST_SEARCH_QUERY_1
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertIn(str(self.table.identifier), c["results"])
-        self.assertEqual(c["results"][str(self.table.identifier)]["data_type"], DATA_TYPE_PHENOPACKET)
-        self.assertEqual(self.phenopacket.id, c["results"][str(self.table.identifier)]["matches"][0]["id"])
+        for method in POST_GET:
+            r = self._search_call("private-search", data={
+                "data_type": DATA_TYPE_PHENOPACKET,
+                "query": TEST_SEARCH_QUERY_1
+            }, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+
+            self.assertIn(str(self.table.identifier), c["results"])
+            self.assertEqual(c["results"][str(self.table.identifier)]["data_type"], DATA_TYPE_PHENOPACKET)
+            self.assertEqual(self.phenopacket.id, c["results"][str(self.table.identifier)]["matches"][0]["id"])
+
         # TODO: Check schema?
 
     def test_private_table_search_1(self):
         # No body
 
-        r = self.client.post(reverse("public-table-search", args=[str(self.table.identifier)]))
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        for method in POST_GET:
+            r = self._search_call("public-table-search", args=[str(self.table.identifier)], method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]))
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_private_table_search_2(self):
         # No query
+        for method in POST_GET:
+            r = self._search_call("public-table-search", args=[str(self.table.identifier)], data={}, method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
-        r = self.client.post(reverse("public-table-search", args=[str(self.table.identifier)]), data=json.dumps({}),
-                             content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
-
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]), data=json.dumps({}),
-                             content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data={}, method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_private_table_search_3(self):
         # Bad syntax for query
+        d = {"query": ["hello", "world"]}
+        for method in POST_GET:
+            r = self._search_call("public-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
-        r = self.client.post(reverse("public-table-search", args=[str(self.table.identifier)]), data=json.dumps({
-            "query": ["hello", "world"]
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
-
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]), data=json.dumps({
-            "query": ["hello", "world"]
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_private_table_search_4(self):
         # Valid query with one result
 
-        r = self.client.post(reverse("public-table-search", args=[str(self.table.identifier)]), data=json.dumps({
-            "query": TEST_SEARCH_QUERY_1
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(c, True)
+        d = {"query": TEST_SEARCH_QUERY_1}
 
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]), data=json.dumps({
-            "query": TEST_SEARCH_QUERY_1
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(len(c["results"]), 1)
-        self.assertEqual(self.phenopacket.id, c["results"][0]["id"])
+        for method in POST_GET:
+            r = self._search_call("public-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(c, True)
+
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 1)
+            self.assertEqual(self.phenopacket.id, c["results"][0]["id"])
 
     def test_private_table_search_5(self):
         # Valid query: literal "true"
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]), data=json.dumps({
-            "query": True
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(len(c["results"]), 1)
-        self.assertEqual(self.phenopacket.id, c["results"][0]["id"])
+
+        d = {"query": True}
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 1)
+            self.assertEqual(self.phenopacket.id, c["results"][0]["id"])
 
     def test_private_table_search_6(self):
         # Valid query to search for phenotypic feature type
 
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]), data=json.dumps({
-            "query": TEST_SEARCH_QUERY_3
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(len(c["results"]), 1)
-        self.assertEqual(len(c["results"][0]["phenotypic_features"]), 1)
-        self.assertEqual(c["results"][0]["phenotypic_features"][0]["type"]["label"], "Proptosis")
+        d = {"query": TEST_SEARCH_QUERY_3}
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 1)
+            self.assertEqual(len(c["results"][0]["phenotypic_features"]), 1)
+            self.assertEqual(c["results"][0]["phenotypic_features"][0]["type"]["label"], "Proptosis")
 
     def test_private_table_search_7(self):
         # Valid query to search for biosample sampled tissue term (this is exact match now only)
 
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]), data=json.dumps({
-            "query": TEST_SEARCH_QUERY_4
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(len(c["results"]), 1)
-        self.assertEqual(len(c["results"][0]["biosamples"]), 2)
-        self.assertIn("bladder", c["results"][0]["biosamples"][0]["sampled_tissue"]["label"])
+        d = {"query": TEST_SEARCH_QUERY_4}
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 1)
+            self.assertEqual(len(c["results"][0]["biosamples"]), 2)
+            self.assertIn("bladder", c["results"][0]["biosamples"][0]["sampled_tissue"]["label"])
 
     def test_private_table_search_8(self):
         # Valid query to search for phenotypic feature type, case-insensitive
 
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]), data=json.dumps({
-            "query": TEST_SEARCH_QUERY_5
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(len(c["results"]), 1)
-        self.assertEqual(len(c["results"][0]["phenotypic_features"]), 1)
+        d = {"query": TEST_SEARCH_QUERY_5}
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 1)
+            self.assertEqual(len(c["results"][0]["phenotypic_features"]), 1)
 
     def test_private_table_search_9(self):
         # Valid query to search for biosample sample tissue label, case-insensitive
 
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]), data=json.dumps({
+        d = {
             "query": TEST_SEARCH_QUERY_6
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(len(c["results"]), 1)
-        self.assertEqual(len(c["results"][0]["biosamples"]), 2)
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 1)
+            self.assertEqual(len(c["results"][0]["biosamples"]), 2)
 
     def test_private_search_10_experiment(self):
         # Valid search with result
-        r = self.client.post(reverse("private-search"), data=json.dumps({
+
+        d = {
             "data_type": DATA_TYPE_EXPERIMENT,
             "query": TEST_SEARCH_QUERY_7
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertIn(str(self.t_exp.identifier), c["results"])
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["data_type"], DATA_TYPE_EXPERIMENT)
-        self.assertEqual(self.experiment.id, c["results"][str(self.t_exp.identifier)]["matches"][0]["id"])
-        self.assertEqual(len(c["results"][str(self.t_exp.identifier)]["matches"]), 1)
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["id"], "experiment:1")
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["study_type"],
-                         "Whole genome Sequencing")
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["molecule"], "total RNA")
-        self.assertEqual(len(c["results"][str(self.t_exp.identifier)]["matches"][0]["experiment_results"]), 1)
-        self.assertEqual(
-            c["results"][str(self.t_exp.identifier)]["matches"][0]["experiment_results"][0]["file_format"], "VCF"
-        )
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["instrument"]["identifier"],
-                         "instrument:01")
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["instrument"]["platform"],
-                         "Illumina")
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["instrument"]["model"],
-                         "Illumina HiSeq 4000")
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["instrument"]["extra_properties"],
-                         {"date": "2021-06-21"})
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-search", data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertIn(str(self.t_exp.identifier), c["results"])
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["data_type"], DATA_TYPE_EXPERIMENT)
+            self.assertEqual(self.experiment.id, c["results"][str(self.t_exp.identifier)]["matches"][0]["id"])
+            self.assertEqual(len(c["results"][str(self.t_exp.identifier)]["matches"]), 1)
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["id"], "experiment:1")
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["study_type"],
+                             "Whole genome Sequencing")
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["molecule"], "total RNA")
+            self.assertEqual(len(c["results"][str(self.t_exp.identifier)]["matches"][0]["experiment_results"]), 1)
+            self.assertEqual(
+                c["results"][str(self.t_exp.identifier)]["matches"][0]["experiment_results"][0]["file_format"], "VCF"
+            )
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["instrument"]["identifier"],
+                             "instrument:01")
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["instrument"]["platform"],
+                             "Illumina")
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["instrument"]["model"],
+                             "Illumina HiSeq 4000")
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["instrument"]["extra_properties"],
+                             {"date": "2021-06-21"})
 
     def test_private_search_11_experiment(self):
         # Valid search with result, case-insensitive search for experiment_type
-        r = self.client.post(reverse("private-search"), data=json.dumps({
+
+        d = {
             "data_type": DATA_TYPE_EXPERIMENT,
             "query": TEST_SEARCH_QUERY_8
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertIn(str(self.t_exp.identifier), c["results"])
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["data_type"], DATA_TYPE_EXPERIMENT)
-        self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["experiment_type"],
-                         "Chromatin Accessibility")
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-search", data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertIn(str(self.t_exp.identifier), c["results"])
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["data_type"], DATA_TYPE_EXPERIMENT)
+            self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["experiment_type"],
+                             "Chromatin Accessibility")
 
     # TODO table search fr experiments
 
     def test_private_table_search_12(self):
         # Valid query to search for subject id
 
-        r = self.client.post(reverse("private-table-search", args=[str(self.table.identifier)]), data=json.dumps({
+        d = {
             "query": TEST_SEARCH_QUERY_9
-        }), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
-        c = r.json()
-        self.assertEqual(len(c["results"]), 1)
-        self.assertIn("patient:1", [phenopacket["subject"]["id"] for phenopacket in c["results"]])
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 1)
+            self.assertIn("patient:1", [phenopacket["subject"]["id"] for phenopacket in c["results"]])
 
     @patch('chord_metadata_service.chord.views_search.es')
     def test_fhir_search(self, mocked_es):

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -312,7 +312,7 @@ QUERY_RESULT_SERIALIZERS = {
 
 def search(request, internal_data=False):
     if request.method == "POST":
-    data_type = request.data.get("data_type")
+        data_type = request.data.get("data_type")
     else:
         data_type = request.query_params.get("data_type")
 
@@ -343,8 +343,7 @@ def search(request, internal_data=False):
             params=params,
             key="table_id"
         ))  # TODO: Maybe can avoid hitting DB here
-        return Response(build_search_response([{"id": t.identifier, "data_type": data_type}
-                                               for t in tables], start))
+        return Response(build_search_response([{"id": t.identifier, "data_type": data_type} for t in tables], start))
 
     serializer_class = QUERY_RESULT_SERIALIZERS[data_type]
     query_function = QUERY_RESULTS_FN[data_type]

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -322,7 +322,12 @@ def search(request, internal_data=False):
     if request.method == "POST":
         query = request.data.get("query")
     else:
-        query = request.query_params.get("query")
+        query = request.query_params.get("query", "null")  # This'll get decoded to None as a fallback case
+
+        try:
+            query = json.loads(query)
+        except json.decoder.JSONDecodeError:
+            return Response(errors.bad_request_error("Invalid query JSON"), status=400)
 
     if query is None:
         return Response(errors.bad_request_error("Missing query in request body"), status=400)
@@ -507,8 +512,14 @@ def chord_table_search_response(request, table_id, internal=False):
 
     if request.method == "POST":
         query = (request.data or {}).get("query")
+
     else:
-        query = request.query_params.get("query")
+        query = request.query_params.get("query", "null")  # This will get decoded to None as a fallback case
+
+        try:
+            query = json.loads(query)
+        except json.decoder.JSONDecodeError:
+            return Response(errors.bad_request_error("Invalid query JSON"), status=400)
 
     if query is None:
         # TODO: Better error

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,6 +74,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sqlparse==0.3.1
 strict-rfc3339==0.7
+tabulate==0.8.9
 toml==0.10.2
 tox==3.22.0
 uritemplate==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         "requests>=2.25.1,<3.0",
         "requests-unixsocket>=0.2.0,<0.3.0",
         "rfc3987==1.3.8",
+        "tabulate>=0.8.9,<0.9",
         "uritemplate>=3.0,<4.0",
     ],
 


### PR DESCRIPTION
* Allows GET requests for all search views in the `chord` app, which should make search results more cacheable
* Adds commands for listing projects/datasets/tables and performing table searches

I think this should be for 2.3.0 rather than a patch release because it introduces a new method to a bunch of API calls.