### PR TITLE
Add public date range filter

### DIFF
--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -203,7 +203,7 @@ class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
                                             if range_value is not None:
                                                 qs = qs.filter(**{range_key: range_value})
                             # add string match filter for all string fields that are not date format
-                            if search_field_val["type"] == "string" and not "format" in search_field_val:
+                            if search_field_val["type"] == "string" and "format" not in search_field_val:
                                 for query_key, query_value in dict_item.items():
                                     if query_key == search_field_key:
                                         qs = qs.filter(

--- a/chord_metadata_service/patients/tests/constants.py
+++ b/chord_metadata_service/patients/tests/constants.py
@@ -1,5 +1,18 @@
 import uuid
 import random
+from datetime import date, timedelta
+from dateutil.relativedelta import relativedelta
+
+
+def generate_random_date(years_from: int, years_to: int):
+    # generates random date in the format YYYY-MM-DD, e.g. 2020-01-01
+    start_date = date.today() - relativedelta(years=years_from)
+    end_date = date.today() - relativedelta(years=years_to)
+    delta = end_date - start_date
+    random_number = random.randint(1, delta.days)
+    new_date = start_date + timedelta(days=random_number)
+    return new_date.strftime('%Y-%m-%d')
+
 
 VALID_INDIVIDUAL = {
     "id": "patient:1",
@@ -69,6 +82,7 @@ def generate_valid_individual():
             "death_dc": random.choice(["Alive", "Deceased"]),
             "covidstatus": random.choice(["Positive", "Negative"]),
             "lab_test_result_value": round(random.uniform(0, 999.99), 2),
-            "baseline_creatinine": round(random.uniform(30, 600), 0)
+            "baseline_creatinine": round(random.uniform(30, 600), 0),
+            "date_of_consent": generate_random_date(3, 0)
         }
     }

--- a/chord_metadata_service/restapi/tests/constants.py
+++ b/chord_metadata_service/restapi/tests/constants.py
@@ -30,7 +30,6 @@ INVALID_SUBJECT_NOT_PRESENT = {
     ]
 }
 
-
 VALID_INDIVIDUAL_1 = {
     "id": "ind:NA19648",
     "date_of_birth": "1993-10-04",
@@ -163,7 +162,6 @@ VALID_INDIVIDUAL_6 = {
     }
 }
 
-
 VALID_INDIVIDUAL_7 = {
     "id": "ind:HG00106",
     "date_of_birth": "1972-06-16",
@@ -210,7 +208,6 @@ VALID_INDIVIDUAL_8 = {
 
 VALID_INDIVIDUALS = [VALID_INDIVIDUAL_1, VALID_INDIVIDUAL_2, VALID_INDIVIDUAL_3, VALID_INDIVIDUAL_4,
                      VALID_INDIVIDUAL_5, VALID_INDIVIDUAL_6, VALID_INDIVIDUAL_7, VALID_INDIVIDUAL_8]
-
 
 CONFIG_FIELDS_TEST = {
     "sex": {
@@ -260,10 +257,14 @@ CONFIG_FIELDS_TEST = {
         "baseline_creatinine": {
             "type": "number",
             "title": "Baseline creatinine"
+        },
+        "date_of_consent": {
+            "type": "string",
+            "format": "date",
+            "title": "Date of consent"
         }
     }
 }
-
 
 CONFIG_FIELDS_TEST_NO_EXTRA_PROPERTIES = {
     "sex": {


### PR DESCRIPTION
This PR addresses:

filtering by range values for date fields in extra_properties:

e.g `/api/public?extra_properties=[{"date_of_consent": {"after": "2020-03-01", "before": "2021-05-01"}}]`
or with after or before ranges only
e.g `/api/public?extra_properties=[{"date_of_consent": {"after": "2020-03-01"}}]`
e.g `/api/public?extra_properties=[{"date_of_consent": {"before": "2021-05-01"}}]`

the filtering relies on config.json schema where string field must have a `format` of `"date"`:
e.g

 ```
 "date_of_consent": {
        "type": "string",
        "format": "date"
  }
```