### PR TITLE
Add public age filtering

### DIFF
--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -173,6 +173,8 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
 class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
     sex = django_filters.CharFilter(lookup_expr="iexact")
     extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
+    age_range_min = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="gte", label="Age range min")
+    age_range_max = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="lte", label="Age range max")
 
     def filter_extra_properties(self, qs, name, value):
         if value.startswith("[") and value.endswith("]"):

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -175,7 +175,6 @@ class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
     sex = django_filters.CharFilter(lookup_expr="iexact")
     # TODO include age filter for all? if no then add this check in the method
     age_range_min = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="gte", label="Age range min")
-    # age_range_max = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="lte", label="Age range max")
     age_range_max = django_filters.NumberFilter(
         field_name="age_numeric", method="filter_age_range_max", label="Age range max"
     )
@@ -183,19 +182,9 @@ class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
 
     def filter_age_range_max(self, qs, name, value):
         if "age" in settings.CONFIG_FIELDS:
-            # TODO is this use case generic? do we need to specify the function in config?
-            if "function" in settings.CONFIG_FIELDS["age"] and \
-                    settings.CONFIG_FIELDS["age"]["function"] == "ceil":
-                from django.db.models.functions import Ceil
-                # from django.db.models import DecimalField
-                # DecimalField.register_lookup(Ceil)
-                # qs = qs.filter(age_numeric__ceil__lt=value)
-                # annotate qs with age_numeric ceiling value, age < ceiling value
-                qs = qs.annotate(age_numeric_ceil=Ceil('age_numeric')).filter(age_numeric_ceil__lt=value)
-
-            else:
-                # age <= value
-                qs = qs.filter(age_numeric__lte=value)
+            from django.db.models.functions import Ceil
+            # annotate qs with age_numeric ceiling value, age < ceiling value
+            qs = qs.annotate(age_numeric_ceil=Ceil('age_numeric')).filter(age_numeric_ceil__lt=value)
         return qs
 
     def filter_extra_properties(self, qs, name, value):

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -171,8 +171,9 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
 
 
 class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
+    # TODO include sex filter for all? if no then add this check in the method
     sex = django_filters.CharFilter(lookup_expr="iexact")
-    age = django_filters.RangeFilter(field_name="age_numeric")
+    # TODO include age filter for all? if no then add this check in the method
     age_range_min = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="gte", label="Age range min")
     # age_range_max = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="lte", label="Age range max")
     age_range_max = django_filters.NumberFilter(
@@ -183,7 +184,7 @@ class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
     def filter_age_range_max(self, qs, name, value):
         if "age" in settings.CONFIG_FIELDS:
             # TODO is this use case generic? do we need to specify the function in config?
-            if "search_function" in settings.CONFIG_FIELDS["age"] and \
+            if "function" in settings.CONFIG_FIELDS["age"] and \
                     settings.CONFIG_FIELDS["age"]["function"] == "ceil":
                 from django.db.models.functions import Ceil
                 # from django.db.models import DecimalField

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -186,9 +186,9 @@ class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
             if "search_function" in settings.CONFIG_FIELDS["age"] and \
                     settings.CONFIG_FIELDS["age"]["function"] == "ceil":
                 from django.db.models.functions import Ceil
-                #from django.db.models import DecimalField
-                #DecimalField.register_lookup(Ceil)
-                # #qs = qs.filter(age_numeric__ceil__lt=value)
+                # from django.db.models import DecimalField
+                # DecimalField.register_lookup(Ceil)
+                # qs = qs.filter(age_numeric__ceil__lt=value)
                 # annotate qs with age_numeric ceiling value, age < ceiling value
                 qs = qs.annotate(age_numeric_ceil=Ceil('age_numeric')).filter(age_numeric_ceil__lt=value)
 

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -198,17 +198,17 @@ class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
         return qs
 
     def filter_extra_properties(self, qs, name, value):
-        if value.startswith("[") and value.endswith("]"):
-            # convert query string value to list
-            try:
-                value_to_list = list(eval(value))
-            # catch if list contains non-existent/random strings (types)
-            except SyntaxError:
-                return qs.none()
-            # check if it's an array of dicts
-            if False not in [isinstance(v, dict) for v in value_to_list]:
-                for dict_item in value_to_list:
-                    if "extra_properties" in settings.CONFIG_FIELDS:
+        if "extra_properties" in settings.CONFIG_FIELDS:
+            if value.startswith("[") and value.endswith("]"):
+                # convert query string value to list
+                try:
+                    value_to_list = list(eval(value))
+                # catch if list contains non-existent/random strings (types)
+                except SyntaxError:
+                    return qs.none()
+                # check if it's an array of dicts
+                if False not in [isinstance(v, dict) for v in value_to_list]:
+                    for dict_item in value_to_list:
                         for search_field_key, search_field_val in settings.CONFIG_FIELDS["extra_properties"].items():
                             # add range filter for all number fields
                             if search_field_val["type"] == "number":
@@ -248,10 +248,10 @@ class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
                                                 # check for both, or only min or max range values
                                                 if range_value is not None:
                                                     qs = qs.filter(**{range_key: range_value})
+                # bad query string return empty queryset
+                else:
+                    return qs.none()
+            # bad query string return empty queryset
             else:
                 return qs.none()
-        # bad query string return empty queryset
-        else:
-            return qs.none()
-
         return qs

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -171,14 +171,24 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
 
 
 class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
-    # TODO include sex filter for all? if no then add this check in the method
-    sex = django_filters.CharFilter(lookup_expr="iexact")
-    # TODO include age filter for all? if no then add this check in the method
-    age_range_min = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="gte", label="Age range min")
+    sex = django_filters.CharFilter(method="filter_sex", label="Sex")
+    age_range_min = django_filters.NumberFilter(
+        field_name="age_numeric", method="filter_age_range_min", label="Age range min"
+    )
     age_range_max = django_filters.NumberFilter(
         field_name="age_numeric", method="filter_age_range_max", label="Age range max"
     )
     extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
+
+    def filter_sex(self, qs, name, value):
+        if "sex" in settings.CONFIG_FIELDS:
+            qs = qs.filter(sex__iexact=value)
+        return qs
+
+    def filter_age_range_min(self, qs, name, value):
+        if "age" in settings.CONFIG_FIELDS:
+            qs = qs.filter(age_numeric__gte=value)
+        return qs
 
     def filter_age_range_max(self, qs, name, value):
         if "age" in settings.CONFIG_FIELDS:

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -172,9 +172,30 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
 
 class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
     sex = django_filters.CharFilter(lookup_expr="iexact")
+    age = django_filters.RangeFilter(field_name="age_numeric")
     age_range_min = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="gte", label="Age range min")
-    age_range_max = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="lte", label="Age range max")
+    # age_range_max = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="lte", label="Age range max")
+    age_range_max = django_filters.NumberFilter(
+        field_name="age_numeric", method="filter_age_range_max", label="Age range max"
+    )
     extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
+
+    def filter_age_range_max(self, qs, name, value):
+        if "age" in settings.CONFIG_FIELDS:
+            # TODO is this use case generic? do we need to specify the function in config?
+            if "search_function" in settings.CONFIG_FIELDS["age"] and \
+                    settings.CONFIG_FIELDS["age"]["function"] == "ceil":
+                from django.db.models.functions import Ceil
+                #from django.db.models import DecimalField
+                #DecimalField.register_lookup(Ceil)
+                # #qs = qs.filter(age_numeric__ceil__lt=value)
+                # annotate qs with age_numeric ceiling value, age < ceiling value
+                qs = qs.annotate(age_numeric_ceil=Ceil('age_numeric')).filter(age_numeric_ceil__lt=value)
+
+            else:
+                # age <= value
+                qs = qs.filter(age_numeric__lte=value)
+        return qs
 
     def filter_extra_properties(self, qs, name, value):
         if value.startswith("[") and value.endswith("]"):

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -172,9 +172,9 @@ class IndividualFilter(django_filters.rest_framework.FilterSet):
 
 class PublicIndividualFilter(django_filters.rest_framework.FilterSet):
     sex = django_filters.CharFilter(lookup_expr="iexact")
-    extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
     age_range_min = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="gte", label="Age range min")
     age_range_max = django_filters.NumberFilter(field_name="age_numeric", lookup_expr="lte", label="Age range max")
+    extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
 
     def filter_extra_properties(self, qs, name, value):
         if value.startswith("[") and value.endswith("]"):

--- a/chord_metadata_service/patients/tests/constants.py
+++ b/chord_metadata_service/patients/tests/constants.py
@@ -74,7 +74,7 @@ def generate_valid_individual():
             "label": "human"
         },
         "age": {
-            "age": f"P{str(random.randrange(16, 89))}Y"
+            "age": f"P{str(random.randrange(16, 89))}Y{str(random.randrange(1, 12))}M{str(random.randrange(1, 31))}D"
         },
         "sex": random.choice(["MALE", "FEMALE", "UNKNOWN_SEX", "OTHER_SEX"]),
         "extra_properties": {

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -210,6 +210,7 @@ class PublicFilteringIndividualsTest(APITestCase):
         for individual in individuals:
             Individual.objects.create(**individual)
 
+    @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_filtering_sex(self):
         # sex field search
         response = self.client.get('/api/public?sex=female')
@@ -265,9 +266,9 @@ class PublicFilteringIndividualsTest(APITestCase):
         response = self.client.get('/api/public?sex=female&extra_properties=[{"smoking": "Non-smoker"}]')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
-        db_count = Individual.objects.filter(sex__iexact='female').count()
-        # if CONFIG_FIELDS is empty then response contains a count of objects filtered
-        # by any other than extra_properties filter or not enough data response if count <= response_threshold
+        db_count = Individual.objects.count()
+        # if CONFIG_FIELDS is empty then response contains a count of all objects
+        # or not enough data response if count <= response_threshold
         # default behaviour
         if db_count > self.response_threshold:
             self.assertEqual(db_count, response_obj['count'])
@@ -292,7 +293,7 @@ class PublicFilteringIndividualsTest(APITestCase):
     # test the same as above but with CONFIG_FIELDS without extra_properties values
     @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST_NO_EXTRA_PROPERTIES)
     def test_public_filtering_extra_properties_1_config_no_extra_properties(self):
-        # sex and extra_properties string search
+        # extra_properties string search
         # test GET query string search for extra_properties field
         response = self.client.get('/api/public?extra_properties=[{"smoking": "Non-smoker"}, {"death_dc": "Deceased"}]')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -311,13 +312,13 @@ class PublicFilteringIndividualsTest(APITestCase):
     # test the same as above but with an empty CONFIG_FIELDS
     @override_settings(CONFIG_FIELDS={})
     def test_public_filtering_extra_properties_1_config_empty(self):
-        # sex and extra_properties string search
+        # extra_properties string search
         # test GET query string search for extra_properties field
         response = self.client.get('/api/public?extra_properties=[{"smoking": "Non-smoker"}, {"death_dc": "Deceased"}]')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         db_count = Individual.objects.count()
-        # if CONFIG_FIELDS is empty then response contains a count of objects in database
+        # if CONFIG_FIELDS is empty then response contains a count of all objects in database
         # or not enough data response if count <= response_threshold
         # default behaviour
         if db_count > self.response_threshold:

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -680,3 +680,5 @@ class PublicAgeRangeFilteringIndividualsTest(APITestCase):
             self.assertEqual(response_obj, self.not_enough_data_response)
         else:
             self.assertEqual(db_count, response_obj['count'])
+
+    # TODO override config value and test for ceiling value

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -344,21 +344,21 @@ class PublicFilteringIndividualsTest(APITestCase):
         else:
             self.assertEqual(db_count, response_obj['count'])
 
-    # don't need to override CONFIG_FIELDS here because this check happens before the CONFIG_FIELDS is called
+    @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_filtering_extra_properties_invalid_1(self):
         # if GET query string doesn't have a list return Not enough data
         response = self.client.get('/api/public?extra_properties="smoking": "Non-smoker","death_dc": "deceased"')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), self.not_enough_data_response)
 
-    # don't need to override CONFIG_FIELDS here because this check happens before the CONFIG_FIELDS is called
+    @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_filtering_extra_properties_invalid_2(self):
         # if GET query string has a random stuff return Not enough data
         response = self.client.get('/api/public?extra_properties=["smoking": "Non-smoker", "5", "Test"]')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), self.not_enough_data_response)
 
-    # don't need to override CONFIG_FIELDS here because this check happens before the CONFIG_FIELDS is called
+    @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_filtering_extra_properties_invalid_3(self):
         # if GET query string list has various data types Not enough data
         response = self.client.get('/api/public?extra_properties=[{"smoking": "Non-smoker"}, 5, "Test"]')

--- a/chord_metadata_service/restapi/tests/constants.py
+++ b/chord_metadata_service/restapi/tests/constants.py
@@ -219,6 +219,10 @@ CONFIG_FIELDS_TEST = {
         "title": "Sex",
         "bin_size": 10
     },
+    "age": {
+        "type": "number",
+        "title": "Age"
+    },
     "extra_properties": {
         "smoking": {
             "type": "string",


### PR DESCRIPTION
This PR addresses:
- age filtering by range values with parameters `age_range_min` and `age_range_max`
        e.g. `/public?age_range_min=10&age_range_max=20`
- `age_range_max` filter returns age < `age_numeric` ceiling value
        e.g. search parameter is `/public?age_range_max=37` and `age_numeric` value is 37.9 years --> the result will include the individual(s) with age 37.9 years (in this case, the ceiling value is 40)