### PR TITLE
Add config availability check

### DIFF
--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -285,9 +285,20 @@ STATIC_URL = '/static/'
 # Cache time constant
 CACHE_TIME = int(os.getenv("CACHE_TIME", 60 * 60 * 2))
 
+# Settings related to the Public APIs
+
 # Read project specific config.json that contains custom search fields
 if os.path.isfile(os.path.join(BASE_DIR, 'config.json')):
     with open(os.path.join(BASE_DIR, 'config.json')) as config_file:
         CONFIG_FIELDS = json.load(config_file)
 else:
     CONFIG_FIELDS = {}
+
+# Public response when there is no enough data that passes the project-custom threshold
+INSUFFICIENT_DATA_AVAILABLE = {"message": "Insufficient information available."}
+
+# Public response when there is no public data available and config file is not provided
+NO_PUBLIC_DATA_AVAILABLE = {"message": "No public data available."}
+
+# Public response when public fields are not configured and config file is not provided
+NO_PUBLIC_FIELDS_CONFIGURED = {"message": "No public fields configured."}

--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -295,7 +295,7 @@ else:
     CONFIG_FIELDS = {}
 
 # Public response when there is no enough data that passes the project-custom threshold
-INSUFFICIENT_DATA_AVAILABLE = {"message": "Insufficient information available."}
+INSUFFICIENT_DATA_AVAILABLE = {"message": "Insufficient data available."}
 
 # Public response when there is no public data available and config file is not provided
 NO_PUBLIC_DATA_AVAILABLE = {"message": "No public data available."}

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -61,8 +61,6 @@ class PublicListIndividuals(APIView):
     def get(self, request, *args, **kwargs):
         base_qs = Individual.objects.all()
         filtered_qs = self.filter_queryset(base_qs)
-        not_enough_data = "Insufficient information available."
-        no_public_data = "There is no public data."
         # protect filtering if config is not provided
         # the settings must be imported from django.conf (not from chord_metadata_service.metadata.settings)
         if settings.CONFIG_FIELDS:
@@ -71,6 +69,6 @@ class PublicListIndividuals(APIView):
                 return Response({"count": filtered_qs.count()})
             else:
                 # the count < 5, when there is no match in db the queryset is empty, count = 0
-                return Response({"message": not_enough_data})
+                return Response(settings.INSUFFICIENT_DATA_AVAILABLE)
         else:
-            return Response({"message": no_public_data})
+            return Response(settings.NO_PUBLIC_DATA_AVAILABLE)

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -17,6 +17,7 @@ from chord_metadata_service.restapi.api_renderers import (
     ARGORenderer,
 )
 from chord_metadata_service.restapi.pagination import LargeResultsSetPagination
+from chord_metadata_service.metadata.settings import CONFIG_FIELDS
 
 
 class IndividualViewSet(viewsets.ModelViewSet):
@@ -62,10 +63,14 @@ class PublicListIndividuals(APIView):
         base_qs = Individual.objects.all()
         filtered_qs = self.filter_queryset(base_qs)
         not_enough_data = "Insufficient information available."
-
-        # the threshold for the count response is set to 5
-        if filtered_qs.count() > 5:
-            return Response({"count": filtered_qs.count()})
+        no_public_data = "There is no public data."
+        # protect filtering if config is not provided
+        if CONFIG_FIELDS:
+            # the threshold for the count response is set to 5
+            if filtered_qs.count() > 5:
+                return Response({"count": filtered_qs.count()})
+            else:
+                # the count < 5, when there is no match in db the queryset is empty, count = 0
+                return Response({"message": not_enough_data})
         else:
-            # the count < 5, when there is no match in db the queryset is empty, count = 0
-            return Response({"message": not_enough_data})
+            return Response({"message": no_public_data})

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -17,7 +17,6 @@ from chord_metadata_service.restapi.api_renderers import (
     ARGORenderer,
 )
 from chord_metadata_service.restapi.pagination import LargeResultsSetPagination
-from chord_metadata_service.metadata.settings import CONFIG_FIELDS
 
 
 class IndividualViewSet(viewsets.ModelViewSet):
@@ -65,7 +64,8 @@ class PublicListIndividuals(APIView):
         not_enough_data = "Insufficient information available."
         no_public_data = "There is no public data."
         # protect filtering if config is not provided
-        if CONFIG_FIELDS:
+        # the settings must be imported from django.conf (not from chord_metadata_service.metadata.settings)
+        if settings.CONFIG_FIELDS:
             # the threshold for the count response is set to 5
             if filtered_qs.count() > 5:
                 return Response({"count": filtered_qs.count()})

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -687,20 +687,18 @@ class PublicAgeRangeFilteringIndividualsTest(APITestCase):
         else:
             self.assertEqual(db_count, response_obj['count'])
 
-    # TODO test with config that doesn't have age field
-    # @override_settings(CONFIG_FIELDS={})
-    # def test_public_filtering_age_range_min_and_max_no_age_in_config(self):
-    #     # test with config, returns initial queryset
-    #     # age range min and max search
-    #     response = self.client.get('/api/public?age_range_min=16&age_range_max=35')
-    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
-    #     response_obj = response.json()
-    #     db_count = Individual.objects.count()
-    #     self.assertIn(self.response_threshold_check(response_obj), [db_count, settings.INSUFFICIENT_DATA_AVAILABLE])
-    #     if db_count <= self.response_threshold:
-    #         self.assertEqual(response_obj, settings.INSUFFICIENT_DATA_AVAILABLE)
-    #     else:
-    #         self.assertEqual(db_count, response_obj['count'])
+    @override_settings(CONFIG_FIELDS={"sex": {"type": "string"}})
+    def test_public_filtering_age_range_min_and_max_no_age_in_config(self):
+        # test with config without age field, returns initial queryset
+        response = self.client.get('/api/public?age_range_min=16&age_range_max=35')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_obj = response.json()
+        db_count = Individual.objects.count()
+        self.assertIn(self.response_threshold_check(response_obj), [db_count, settings.INSUFFICIENT_DATA_AVAILABLE])
+        if db_count <= self.response_threshold:
+            self.assertEqual(response_obj, settings.INSUFFICIENT_DATA_AVAILABLE)
+        else:
+            self.assertEqual(db_count, response_obj['count'])
 
     @override_settings(CONFIG_FIELDS={})
     def test_public_filtering_age_range_min_and_max_no_config(self):

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -171,19 +171,20 @@ class PublicListIndividualsTest(APITestCase):
     """ Test for api/public GET all """
 
     response_threshold = 5
+    random_range = 137
 
     @staticmethod
     def response_threshold_check(response):
         return response['count'] if 'count' in response else settings.INSUFFICIENT_DATA_AVAILABLE
 
     def setUp(self):
-        individuals = [c.generate_valid_individual() for _ in range(137)]  # random range
+        individuals = [c.generate_valid_individual() for _ in range(self.random_range)]  # random range
         for individual in individuals:
             Individual.objects.create(**individual)
 
     @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_get(self):
-        # no filters GET request to /api/public, returns count or not enough data
+        # no filters GET request to /api/public, returns count or INSUFFICIENT_DATA_AVAILABLE
         response = self.client.get('/api/public')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
@@ -198,12 +199,11 @@ class PublicListIndividualsTest(APITestCase):
 
     @override_settings(CONFIG_FIELDS={})
     def test_public_get_no_config(self):
-        # no filters GET request to /api/public, returns count or not enough data
+        # no filters GET request to /api/public when config is not provided, returns NO_PUBLIC_DATA_AVAILABLE
         response = self.client.get('/api/public')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         self.assertIsInstance(response_obj, dict)
-        # if config is empty then there is no public data available
         self.assertEqual(response_obj, settings.NO_PUBLIC_DATA_AVAILABLE)
 
 
@@ -705,6 +705,7 @@ class PublicAgeRangeFilteringIndividualsTest(APITestCase):
 
     @override_settings(CONFIG_FIELDS={})
     def test_public_filtering_age_range_min_and_max_no_config(self):
+        # test when config is not provided, returns NO_PUBLIC_DATA_AVAILABLE
         response = self.client.get('/api/public?age_range_min=16&age_range_max=35')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -707,7 +707,6 @@ class PublicAgeRangeFilteringIndividualsTest(APITestCase):
     #     else:
     #         self.assertEqual(db_count, response_obj['count'])
 
-
     @override_settings(CONFIG_FIELDS={})
     def test_public_filtering_age_range_min_and_max_no_config(self):
         response = self.client.get('/api/public?age_range_min=16&age_range_max=35')

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -172,7 +172,8 @@ class PublicListIndividualsTest(APITestCase):
 
     response_threshold = 5
 
-    def response_threshold_check(self, response):
+    @staticmethod
+    def response_threshold_check(response):
         return response['count'] if 'count' in response else settings.INSUFFICIENT_DATA_AVAILABLE
 
     def setUp(self):
@@ -212,7 +213,8 @@ class PublicFilteringIndividualsTest(APITestCase):
     response_threshold = 5
     random_range = 137
 
-    def response_threshold_check(self, response):
+    @staticmethod
+    def response_threshold_check(response):
         return response['count'] if 'count' in response else settings.INSUFFICIENT_DATA_AVAILABLE
 
     def setUp(self):
@@ -344,21 +346,21 @@ class PublicFilteringIndividualsTest(APITestCase):
 
     @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_filtering_extra_properties_invalid_1(self):
-        # if GET query string doesn't have a list return Not enough data
+        # if GET query string doesn't have a list return INSUFFICIENT_DATA_AVAILABLE
         response = self.client.get('/api/public?extra_properties="smoking": "Non-smoker","death_dc": "deceased"')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), settings.INSUFFICIENT_DATA_AVAILABLE)
 
     @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_filtering_extra_properties_invalid_2(self):
-        # if GET query string has a random stuff return Not enough data
+        # if GET query string has a random stuff return INSUFFICIENT_DATA_AVAILABLE
         response = self.client.get('/api/public?extra_properties=["smoking": "Non-smoker", "5", "Test"]')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), settings.INSUFFICIENT_DATA_AVAILABLE)
 
     @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_filtering_extra_properties_invalid_3(self):
-        # if GET query string list has various data types Not enough data
+        # if GET query string list has various data types INSUFFICIENT_DATA_AVAILABLE
         response = self.client.get('/api/public?extra_properties=[{"smoking": "Non-smoker"}, 5, "Test"]')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), settings.INSUFFICIENT_DATA_AVAILABLE)
@@ -624,7 +626,8 @@ class PublicAgeRangeFilteringIndividualsTest(APITestCase):
     response_threshold = 5
     random_range = 45
 
-    def response_threshold_check(self, response):
+    @staticmethod
+    def response_threshold_check(response):
         return response['count'] if 'count' in response else settings.INSUFFICIENT_DATA_AVAILABLE
 
     def setUp(self):

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -197,7 +197,7 @@ class PublicListIndividualsTest(APITestCase):
             self.assertEqual(Individual.objects.all().count(), response_obj['count'])
 
     @override_settings(CONFIG_FIELDS={})
-    def test_public_get(self):
+    def test_public_get_no_config(self):
         # no filters GET request to /api/public, returns count or not enough data
         response = self.client.get('/api/public')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -282,7 +282,6 @@ class PublicFilteringIndividualsTest(APITestCase):
         self.assertIsInstance(response_obj, dict)
         self.assertEqual(response_obj, self.no_public_data)
 
-
     @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_filtering_extra_properties_1(self):
         # extra_properties string search (multiple values)
@@ -327,7 +326,6 @@ class PublicFilteringIndividualsTest(APITestCase):
         response_obj = response.json()
         self.assertIsInstance(response_obj, dict)
         self.assertEqual(response_obj, self.no_public_data)
-
 
     @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_public_filtering_extra_properties_2(self):
@@ -718,4 +716,3 @@ class PublicAgeRangeFilteringIndividualsTest(APITestCase):
         self.assertIsInstance(response_obj, dict)
         self.assertIsInstance(response_obj, dict)
         self.assertEqual(response_obj, self.no_public_data)
-

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -312,85 +312,95 @@ def public_overview(_request):
     # TODO should this be added to the project config.json file ?
     threshold = 5
     not_enough_data = "Insufficient information available."
+    no_public_data = "There is no public data."
 
-    individuals = patients_models.Individual.objects.all()
-    individuals_set = set()
-    individuals_sex = Counter()
-    individuals_age = Counter()
-    individuals_extra_properties = {}
-    extra_properties = {}
+    if CONFIG_FIELDS:
+        individuals = patients_models.Individual.objects.all()
+        individuals_set = set()
+        individuals_sex = Counter()
+        individuals_age = Counter()
+        individuals_extra_properties = {}
+        extra_properties = {}
 
-    experiments = experiments_models.Experiment.objects.all()
-    experiments_set = set()
-    experiments_type = Counter()
+        experiments = experiments_models.Experiment.objects.all()
+        experiments_set = set()
+        experiments_type = Counter()
 
-    for individual in individuals:
-        # subject/individual
-        individuals_set.add(individual.id)
-        individuals_sex.update((individual.sex,))
-        # age
-        if individual.age is not None:
-            individuals_age.update((parse_individual_age(individual.age),))
-        # collect extra_properties defined in config
-        if individual.extra_properties and "extra_properties" in CONFIG_FIELDS:
-            for key in individual.extra_properties:
-                if key in CONFIG_FIELDS["extra_properties"]:
-                    # add new Counter()
-                    if key not in extra_properties:
-                        extra_properties[key] = Counter()
-                    extra_properties[key].update((individual.extra_properties[key],))
-                    individuals_extra_properties[key] = dict(extra_properties[key])
-    # experiments
-    for experiment in experiments:
-        experiments_set.add(experiment.id)
-        experiments_type.update((experiment.experiment_type,))
+        for individual in individuals:
+            # subject/individual
+            individuals_set.add(individual.id)
+            individuals_sex.update((individual.sex,))
+            # age
+            if individual.age is not None:
+                individuals_age.update((parse_individual_age(individual.age),))
+            # collect extra_properties defined in config
+            if individual.extra_properties and "extra_properties" in CONFIG_FIELDS:
+                for key in individual.extra_properties:
+                    if key in CONFIG_FIELDS["extra_properties"]:
+                        # add new Counter()
+                        if key not in extra_properties:
+                            extra_properties[key] = Counter()
+                        extra_properties[key].update((individual.extra_properties[key],))
+                        individuals_extra_properties[key] = dict(extra_properties[key])
+        # Experiments
+        for experiment in experiments:
+            experiments_set.add(experiment.id)
+            experiments_type.update((experiment.experiment_type,))
 
-    # Put age in bins
-    if individuals_age:
-        age_bin_size = CONFIG_FIELDS["age"]["bin_size"] \
-            if "age" in CONFIG_FIELDS and "bin_size" in CONFIG_FIELDS["age"] else None
-        age_kwargs = dict(values=dict(individuals_age), bin_size=age_bin_size)
-        individuals_age_bins = sort_numeric_values_into_bins(**{k: v for k, v in age_kwargs.items() if v is not None})
+        # Put age in bins
+        if individuals_age:
+            age_bin_size = CONFIG_FIELDS["age"]["bin_size"] \
+                if "age" in CONFIG_FIELDS and "bin_size" in CONFIG_FIELDS["age"] else None
+            age_kwargs = dict(values=dict(individuals_age), bin_size=age_bin_size)
+            individuals_age_bins = sort_numeric_values_into_bins(**{k: v for k, v in age_kwargs.items() if v is not None})
+        else:
+            individuals_age_bins = {}
+
+        # Put all other numeric values coming from extra_properties in bins and remove values where count <= threshold
+        if individuals_extra_properties:
+            for key, value in list(individuals_extra_properties.items()):
+                # extra_properties contains only the fields specified in config
+                if CONFIG_FIELDS["extra_properties"][key]["type"] == "number":
+                    # retrieve bin_size if available
+                    field_bin_size = CONFIG_FIELDS["extra_properties"][key]["bin_size"] \
+                        if "bin_size" in CONFIG_FIELDS["extra_properties"][key] else None
+                    # retrieve the values from extra_properties counter
+                    values = individuals_extra_properties[key]
+                    kwargs = dict(values=values, bin_size=field_bin_size)
+                    # sort into bins and remove numeric values where count <= threshold
+                    extra_prop_values_in_bins = sort_numeric_values_into_bins(
+                        **{k: v for k, v in kwargs.items() if v is not None}
+                    )
+                    # rewrite with sorted values
+                    individuals_extra_properties[key] = extra_prop_values_in_bins
+                # remove string values where count <= threshold
+                else:
+                    for k, v in list(value.items()):
+                        if v <= 5:
+                            individuals_extra_properties[key].pop(k)
+
+        # Response content
+        if len(individuals_set) < threshold:
+            content = {"message": not_enough_data}
+        else:
+            content = {
+                "individuals": len(individuals_set)
+            }
+            for field, value in zip(
+                    ["sex", "age", "extra_properties", "experiment_type"],
+                    [{k: v for k, v in dict(individuals_sex).items() if v > threshold},
+                     individuals_age_bins,
+                     individuals_extra_properties,
+                     dict(experiments_type)]):
+                if field in CONFIG_FIELDS:
+                    content[field] = value
+            if "experiment_type" in content:
+                content["experiments"] = len(experiments_set)
+        return Response(content)
+
     else:
-        individuals_age_bins = {}
-
-    # Put all other numeric values coming from extra_properties in bins and remove values where count <= threshold
-    if individuals_extra_properties:
-        for key, value in list(individuals_extra_properties.items()):
-            # extra_properties contains only the fields specified in config
-            if CONFIG_FIELDS["extra_properties"][key]["type"] == "number":
-                # retrieve bin_size if available
-                field_bin_size = CONFIG_FIELDS["extra_properties"][key]["bin_size"] \
-                    if "bin_size" in CONFIG_FIELDS["extra_properties"][key] else None
-                # retrieve the values from extra_properties counter
-                values = individuals_extra_properties[key]
-                kwargs = dict(values=values, bin_size=field_bin_size)
-                # sort into bins and remove numeric values where count <= threshold
-                extra_prop_values_in_bins = sort_numeric_values_into_bins(
-                    **{k: v for k, v in kwargs.items() if v is not None}
-                )
-                # rewrite with sorted values
-                individuals_extra_properties[key] = extra_prop_values_in_bins
-            # remove string values where count <= threshold
-            else:
-                for k, v in list(value.items()):
-                    if v <= 5:
-                        individuals_extra_properties[key].pop(k)
-
-    # Response content
-    if len(individuals_set) < threshold:
-        content = {"message": not_enough_data}
-    else:
-        content = {
-            "individuals": len(individuals_set),
-            "sex": {k: v for k, v in dict(individuals_sex).items() if v > threshold},
-            "age": individuals_age_bins,
-            "extra_properties": individuals_extra_properties,
-            # TODO ?? same for experiments ??
-            "experiments": len(experiments_set),
-            "experiment_type": dict(experiments_type)
-        }
-    return Response(content)
+        content = {"message": no_public_data}
+        return Response(content)
 
 
 def sort_numeric_values_into_bins(values: dict, bin_size: int = 10, threshold: int = 5):

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -352,7 +352,9 @@ def public_overview(_request):
             age_bin_size = CONFIG_FIELDS["age"]["bin_size"] \
                 if "age" in CONFIG_FIELDS and "bin_size" in CONFIG_FIELDS["age"] else None
             age_kwargs = dict(values=dict(individuals_age), bin_size=age_bin_size)
-            individuals_age_bins = sort_numeric_values_into_bins(**{k: v for k, v in age_kwargs.items() if v is not None})
+            individuals_age_bins = sort_numeric_values_into_bins(
+                **{k: v for k, v in age_kwargs.items() if v is not None}
+            )
         else:
             individuals_age_bins = {}
 

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -298,7 +298,7 @@ def public_search_fields(_request):
     if settings.CONFIG_FIELDS:
         return Response(settings.CONFIG_FIELDS)
     else:
-        return Response("No public search fields configured.")
+        return Response(settings.NO_PUBLIC_FIELDS_CONFIGURED)
 
 
 @api_view(["GET"])
@@ -311,8 +311,6 @@ def public_overview(_request):
 
     # TODO should this be added to the project config.json file ?
     threshold = 5
-    not_enough_data = "Insufficient information available."
-    no_public_data = "There is no public data."
 
     if settings.CONFIG_FIELDS:
         individuals = patients_models.Individual.objects.all()
@@ -383,7 +381,7 @@ def public_overview(_request):
 
         # Response content
         if len(individuals_set) < threshold:
-            content = {"message": not_enough_data}
+            content = settings.INSUFFICIENT_DATA_AVAILABLE
         else:
             content = {
                 "individuals": len(individuals_set)
@@ -401,8 +399,7 @@ def public_overview(_request):
         return Response(content)
 
     else:
-        content = {"message": no_public_data}
-        return Response(content)
+        return Response(settings.NO_PUBLIC_DATA_AVAILABLE)
 
 
 def sort_numeric_values_into_bins(values: dict, bin_size: int = 10, threshold: int = 5):

--- a/chord_metadata_service/restapi/tests/constants.py
+++ b/chord_metadata_service/restapi/tests/constants.py
@@ -216,12 +216,12 @@ CONFIG_FIELDS_TEST = {
             "Male",
             "Female"
         ],
-        "title": "Sex",
-        "bin_size": 10
+        "title": "Sex"
     },
     "age": {
         "type": "number",
-        "title": "Age"
+        "title": "Age",
+        "bin_size": 10
     },
     "extra_properties": {
         "smoking": {

--- a/chord_metadata_service/restapi/tests/test_api.py
+++ b/chord_metadata_service/restapi/tests/test_api.py
@@ -145,18 +145,20 @@ class McodeOverviewTest(APITestCase):
 
 class PublicSearchFieldsTest(APITestCase):
     def test_public_search_fields(self):
-        r = self.client.get(reverse("public-search-fields"), content_type="application/json")
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        response = self.client.get(reverse("public-search-fields"), content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_obj = response.json()
         if settings.CONFIG_FIELDS:
-            self.assertDictEqual(r.json(), settings.CONFIG_FIELDS)
+            self.assertDictEqual(response_obj, settings.CONFIG_FIELDS)
         else:
-            self.assertIsInstance(r.json(), str)
+            self.assertIsInstance(response_obj, dict)
+            self.assertEqual(response_obj, settings.NO_PUBLIC_FIELDS_CONFIGURED)
 
 
 class PublicOverviewTest(APITestCase):
 
     def setUp(self) -> None:
-        # individuals
+        # individuals (count 8)
         individuals = {
             f"individual_{i}": ph_m.Individual.objects.create(**ind) for i, ind in enumerate(VALID_INDIVIDUALS, start=1)
         }
@@ -192,7 +194,7 @@ class PublicOverviewTest(APITestCase):
         response = self.client.get('/api/public_overview')
         response_obj = response.json()
         self.assertIsInstance(response_obj, dict)
-        # self.assertEqual(response_obj, no_public_data)
+        self.assertEqual(response_obj, settings.NO_PUBLIC_DATA_AVAILABLE)
 
 
 class PublicOverviewTest2(APITestCase):
@@ -210,6 +212,7 @@ class PublicOverviewTest2(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsInstance(response_obj, dict)
         self.assertNotIn("individuals", response_obj)
+        self.assertEqual(response_obj, settings.INSUFFICIENT_DATA_AVAILABLE)
 
     @override_settings(CONFIG_FIELDS={})
     def test_overview_response_no_config(self):
@@ -217,4 +220,4 @@ class PublicOverviewTest2(APITestCase):
         response = self.client.get('/api/public_overview')
         response_obj = response.json()
         self.assertIsInstance(response_obj, dict)
-        # self.assertEqual(response_obj, no_public_data)
+        self.assertEqual(response_obj, settings.NO_PUBLIC_DATA_AVAILABLE)

--- a/chord_metadata_service/restapi/tests/test_api.py
+++ b/chord_metadata_service/restapi/tests/test_api.py
@@ -144,15 +144,21 @@ class McodeOverviewTest(APITestCase):
 
 
 class PublicSearchFieldsTest(APITestCase):
-    def test_public_search_fields(self):
+
+    @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
+    def test_public_search_fields_configured(self):
         response = self.client.get(reverse("public-search-fields"), content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
-        if settings.CONFIG_FIELDS:
-            self.assertDictEqual(response_obj, settings.CONFIG_FIELDS)
-        else:
-            self.assertIsInstance(response_obj, dict)
-            self.assertEqual(response_obj, settings.NO_PUBLIC_FIELDS_CONFIGURED)
+        self.assertDictEqual(response_obj, settings.CONFIG_FIELDS)
+
+    @override_settings(CONFIG_FIELDS={})
+    def test_public_search_fields_not_configured(self):
+        response = self.client.get(reverse("public-search-fields"), content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_obj = response.json()
+        self.assertIsInstance(response_obj, dict)
+        self.assertEqual(response_obj, settings.NO_PUBLIC_FIELDS_CONFIGURED)
 
 
 class PublicOverviewTest(APITestCase):

--- a/chord_metadata_service/restapi/tests/test_api.py
+++ b/chord_metadata_service/restapi/tests/test_api.py
@@ -192,7 +192,7 @@ class PublicOverviewTest(APITestCase):
         response = self.client.get('/api/public_overview')
         response_obj = response.json()
         self.assertIsInstance(response_obj, dict)
-        #self.assertEqual(response_obj, no_public_data)
+        # self.assertEqual(response_obj, no_public_data)
 
 
 class PublicOverviewTest2(APITestCase):
@@ -212,7 +212,7 @@ class PublicOverviewTest2(APITestCase):
         self.assertNotIn("individuals", response_obj)
 
     @override_settings(CONFIG_FIELDS={})
-    def test_overview_response(self):
+    def test_overview_response_no_config(self):
         # test overview response when individuals count < threshold
         response = self.client.get('/api/public_overview')
         response_obj = response.json()

--- a/chord_metadata_service/restapi/tests/test_api.py
+++ b/chord_metadata_service/restapi/tests/test_api.py
@@ -1,16 +1,18 @@
 from copy import deepcopy
+from django.conf import settings
 from django.urls import reverse
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from chord_metadata_service.metadata.service_info import SERVICE_INFO
-from chord_metadata_service.metadata.settings import CONFIG_FIELDS
 from chord_metadata_service.phenopackets import models as ph_m
 from chord_metadata_service.phenopackets.tests import constants as ph_c
 from chord_metadata_service.experiments import models as exp_m
 from chord_metadata_service.experiments.tests import constants as exp_c
 from chord_metadata_service.mcode import models as mcode_m
 from chord_metadata_service.mcode.tests import constants as mcode_c
+from .constants import CONFIG_FIELDS_TEST
 
 from .constants import VALID_INDIVIDUALS
 
@@ -145,8 +147,8 @@ class PublicSearchFieldsTest(APITestCase):
     def test_public_search_fields(self):
         r = self.client.get(reverse("public-search-fields"), content_type="application/json")
         self.assertEqual(r.status_code, status.HTTP_200_OK)
-        if CONFIG_FIELDS:
-            self.assertDictEqual(r.json(), CONFIG_FIELDS)
+        if settings.CONFIG_FIELDS:
+            self.assertDictEqual(r.json(), settings.CONFIG_FIELDS)
         else:
             self.assertIsInstance(r.json(), str)
 
@@ -176,6 +178,7 @@ class PublicOverviewTest(APITestCase):
         experiment_2["id"] = "experiment:2"
         self.experiment = exp_m.Experiment.objects.create(**experiment_2)
 
+    @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_overview(self):
         response = self.client.get('/api/public_overview')
         response_obj = response.json()
@@ -183,6 +186,13 @@ class PublicOverviewTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsInstance(response_obj, dict)
         self.assertEqual(response_obj["individuals"], db_count)
+
+    @override_settings(CONFIG_FIELDS={})
+    def test_overview_no_config(self):
+        response = self.client.get('/api/public_overview')
+        response_obj = response.json()
+        self.assertIsInstance(response_obj, dict)
+        #self.assertEqual(response_obj, no_public_data)
 
 
 class PublicOverviewTest2(APITestCase):
@@ -192,6 +202,7 @@ class PublicOverviewTest2(APITestCase):
         for ind in VALID_INDIVIDUALS[:2]:
             ph_m.Individual.objects.create(**ind)
 
+    @override_settings(CONFIG_FIELDS=CONFIG_FIELDS_TEST)
     def test_overview_response(self):
         # test overview response when individuals count < threshold
         response = self.client.get('/api/public_overview')
@@ -199,3 +210,11 @@ class PublicOverviewTest2(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsInstance(response_obj, dict)
         self.assertNotIn("individuals", response_obj)
+
+    @override_settings(CONFIG_FIELDS={})
+    def test_overview_response(self):
+        # test overview response when individuals count < threshold
+        response = self.client.get('/api/public_overview')
+        response_obj = response.json()
+        self.assertIsInstance(response_obj, dict)
+        # self.assertEqual(response_obj, no_public_data)


### PR DESCRIPTION
This PR:
-  adds NO_PUBLIC_DATA_AVAILABLE response for `/public`, `/public` filtering and `/public_overview` endpoints if the config file is not provided
- moves all static Public APIs responses in `settings.py`
- adds tests for NO_PUBLIC_DATA_AVAILABLE  response