### PR TITLE
Add type exception for public overview count

### DIFF
--- a/chord_metadata_service/package.cfg
+++ b/chord_metadata_service/package.cfg
@@ -1,4 +1,4 @@
 [package]
 name = katsu
-version = 2.9.1
+version = 2.9.2
 authors = Ksenia Zaytseva, David Lougheed, Simon Chénard, Romain Grégoire

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -349,6 +349,8 @@ def public_overview(_request):
                             extra_properties[key].update((individual.extra_properties[key],))
                         except TypeError:
                             logger.error(f"The extra_properties {key} value is not of type string or number.")
+                            pass
+
                         individuals_extra_properties[key] = dict(extra_properties[key])
         # Experiments
         for experiment in experiments:
@@ -376,13 +378,14 @@ def public_overview(_request):
                         if "bin_size" in settings.CONFIG_FIELDS["extra_properties"][key] else None
                     # retrieve the values from extra_properties counter
                     values = individuals_extra_properties[key]
-                    kwargs = dict(values=values, bin_size=field_bin_size)
-                    # sort into bins and remove numeric values where count <= threshold
-                    extra_prop_values_in_bins = sort_numeric_values_into_bins(
-                        **{k: v for k, v in kwargs.items() if v is not None}
-                    )
-                    # rewrite with sorted values
-                    individuals_extra_properties[key] = extra_prop_values_in_bins
+                    if values:
+                        kwargs = dict(values=values, bin_size=field_bin_size)
+                        # sort into bins and remove numeric values where count <= threshold
+                        extra_prop_values_in_bins = sort_numeric_values_into_bins(
+                            **{k: v for k, v in kwargs.items() if v is not None}
+                        )
+                        # rewrite with sorted values
+                        individuals_extra_properties[key] = extra_prop_values_in_bins
                     # add missing value count
                     individuals_extra_properties[key][missing] = len(individuals_set) - sum(v for v in value.values())
                 else:

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -1,4 +1,6 @@
 import math
+import logging
+
 from collections import Counter
 from django.conf import settings
 from django.views.decorators.cache import cache_page
@@ -15,6 +17,10 @@ from chord_metadata_service.mcode import models as mcode_models
 from chord_metadata_service.patients import models as patients_models
 from chord_metadata_service.experiments import models as experiments_models
 from chord_metadata_service.mcode.api_views import MCODEPACKET_PREFETCH, MCODEPACKET_SELECT
+
+
+logger = logging.getLogger("restapi_api_views")
+logger.setLevel(logging.INFO)
 
 
 @api_view()
@@ -339,7 +345,10 @@ def public_overview(_request):
                         # add new Counter()
                         if key not in extra_properties:
                             extra_properties[key] = Counter()
-                        extra_properties[key].update((individual.extra_properties[key],))
+                        try:
+                            extra_properties[key].update((individual.extra_properties[key],))
+                        except TypeError:
+                            logger.error(f"The extra_properties {key} value is not of type string or number.")
                         individuals_extra_properties[key] = dict(extra_properties[key])
         # Experiments
         for experiment in experiments:

--- a/chord_metadata_service/restapi/tests/constants.py
+++ b/chord_metadata_service/restapi/tests/constants.py
@@ -1,3 +1,6 @@
+from copy import deepcopy
+
+
 INVALID_FHIR_BUNDLE_1 = {
     "resourceType": "NotBundle",
     "entry": [
@@ -208,6 +211,40 @@ VALID_INDIVIDUAL_8 = {
 
 VALID_INDIVIDUALS = [VALID_INDIVIDUAL_1, VALID_INDIVIDUAL_2, VALID_INDIVIDUAL_3, VALID_INDIVIDUAL_4,
                      VALID_INDIVIDUAL_5, VALID_INDIVIDUAL_6, VALID_INDIVIDUAL_7, VALID_INDIVIDUAL_8]
+
+
+extra_properties_with_list = {
+        "smoking": "Former smoker",
+        "covidstatus": "Positive",
+        "death_dc": "Alive",
+        "mobility": "I have slight problems in walking about",
+        "date_of_consent": "2021-03-03",
+        "lab_test_result_value": 699.86,
+        "baseline_creatinine": [100, 120]
+    }
+
+extra_properties_with_dict = {
+        "smoking": "Former smoker",
+        "covidstatus": "Positive",
+        "death_dc": "Alive",
+        "mobility": "I have slight problems in walking about",
+        "date_of_consent": "2021-03-03",
+        "lab_test_result_value": 699.86,
+        "baseline_creatinine": {
+            "test_key_1": 120,
+            "test_key_2": "test_value_2"
+        }
+    }
+
+
+INDIVIDUALS_NOT_ACCEPTED_DATA_TYPES_LIST = [
+    {**item, "extra_properties": extra_properties_with_list} for item in deepcopy(VALID_INDIVIDUALS)
+]
+
+INDIVIDUALS_NOT_ACCEPTED_DATA_TYPES_DICT = [
+    {**item, "extra_properties": extra_properties_with_dict} for item in deepcopy(VALID_INDIVIDUALS)
+]
+
 
 CONFIG_FIELDS_TEST = {
     "sex": {


### PR DESCRIPTION
Currently, the public overview does not provide count calculation for values that are represented as an object or an array.
This patch adds a TypeError exception.