### PR TITLE
Add Experiment results endpoint

### DIFF
--- a/chord_metadata_service/experiments/api_views.py
+++ b/chord_metadata_service/experiments/api_views.py
@@ -7,10 +7,10 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django_filters.rest_framework import DjangoFilterBackend
 
-from .serializers import ExperimentSerializer
-from .models import Experiment
+from .serializers import ExperimentSerializer, ExperimentResultSerializer
+from .models import Experiment, ExperimentResult
 from .schemas import EXPERIMENT_SCHEMA
-from .filters import ExperimentFilter
+from .filters import ExperimentFilter, ExperimentResultFilter
 from chord_metadata_service.restapi.pagination import LargeResultsSetPagination
 
 __all__ = [
@@ -52,6 +52,28 @@ class ExperimentViewSet(viewsets.ModelViewSet):
     @method_decorator(cache_page(60 * 60 * 2))
     def dispatch(self, *args, **kwargs):
         return super(ExperimentViewSet, self).dispatch(*args, **kwargs)
+
+
+class ExperimentResultViewSet(viewsets.ModelViewSet):
+    """
+    get:
+    Return a list of all existing experiment results
+
+    post:
+    Create a new experiment result
+    """
+
+    queryset = ExperimentResult.objects.all()
+    serializer_class = ExperimentResultSerializer
+    pagination_class = LargeResultsSetPagination
+    renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES)
+    filter_backends = [DjangoFilterBackend]
+    filter_class = ExperimentResultFilter
+
+    # Cache page for the requested url for 2 hours
+    @method_decorator(cache_page(60 * 60 * 2))
+    def dispatch(self, *args, **kwargs):
+        return super(ExperimentResultViewSet, self).dispatch(*args, **kwargs)
 
 
 @api_view(["GET"])

--- a/chord_metadata_service/experiments/api_views.py
+++ b/chord_metadata_service/experiments/api_views.py
@@ -63,7 +63,7 @@ class ExperimentResultViewSet(viewsets.ModelViewSet):
     Create a new experiment result
     """
 
-    queryset = ExperimentResult.objects.all()
+    queryset = ExperimentResult.objects.all().order_by("id")
     serializer_class = ExperimentResultSerializer
     pagination_class = LargeResultsSetPagination
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES)

--- a/chord_metadata_service/experiments/filters.py
+++ b/chord_metadata_service/experiments/filters.py
@@ -1,4 +1,5 @@
 import django_filters
+from chord_metadata_service.phenopackets.filters import filter_datasets
 from .models import Experiment, ExperimentResult
 
 
@@ -31,6 +32,12 @@ class ExperimentResultFilter(django_filters.rest_framework.FilterSet):
     usage = django_filters.CharFilter(lookup_expr='icontains')
     created_by = django_filters.CharFilter(lookup_expr='icontains')
     extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
+    # filter by datasets
+    datasets = django_filters.CharFilter(
+        method=filter_datasets,
+        field_name="experiment__table__ownership_record__dataset__title",
+        label="Datasets"
+    )
 
     class Meta:
         model = ExperimentResult

--- a/chord_metadata_service/experiments/filters.py
+++ b/chord_metadata_service/experiments/filters.py
@@ -1,5 +1,5 @@
 import django_filters
-from .models import Experiment
+from .models import Experiment, ExperimentResult
 
 
 class ExperimentFilter(django_filters.rest_framework.FilterSet):
@@ -16,6 +16,25 @@ class ExperimentFilter(django_filters.rest_framework.FilterSet):
     class Meta:
         model = Experiment
         fields = ["id", "reference_registry_id", "biosample"]
+
+    def filter_extra_properties(self, qs, name, value):
+        return qs.filter(extra_properties__icontains=value)
+
+
+class ExperimentResultFilter(django_filters.rest_framework.FilterSet):
+    identifier = django_filters.CharFilter(lookup_expr='exact')
+    description = django_filters.CharFilter(lookup_expr='icontains')
+    filename = django_filters.CharFilter(lookup_expr='icontains')
+    genome_assembly_id = django_filters.CharFilter(lookup_expr='iexact')
+    file_format = django_filters.CharFilter(lookup_expr='iexact')
+    data_output_type = django_filters.CharFilter(lookup_expr='icontains')
+    usage = django_filters.CharFilter(lookup_expr='icontains')
+    created_by = django_filters.CharFilter(lookup_expr='icontains')
+    extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
+
+    class Meta:
+        model = ExperimentResult
+        exclude = ["creation_date", "created", "updated"]
 
     def filter_extra_properties(self, qs, name, value):
         return qs.filter(extra_properties__icontains=value)

--- a/chord_metadata_service/experiments/filters.py
+++ b/chord_metadata_service/experiments/filters.py
@@ -13,6 +13,12 @@ class ExperimentFilter(django_filters.rest_framework.FilterSet):
     library_layout = django_filters.CharFilter(lookup_expr='icontains')
     extraction_protocol = django_filters.CharFilter(lookup_expr='icontains')
     extra_properties = django_filters.CharFilter(method="filter_extra_properties", label="Extra properties")
+    # filter by datasets
+    datasets = django_filters.CharFilter(
+        method=filter_datasets,
+        field_name="table__ownership_record__dataset__title",
+        label="Datasets"
+    )
 
     class Meta:
         model = Experiment

--- a/chord_metadata_service/experiments/tests/example_experiments.json
+++ b/chord_metadata_service/experiments/tests/example_experiments.json
@@ -1,0 +1,142 @@
+{
+  "experiments": [
+    {
+      "id": "experiment:1",
+      "biosample": "sample1",
+      "study_type": "Epigenomics",
+      "experiment_type": "Histone H3K27ac",
+      "experiment_ontology": [
+        {
+          "id": "EFO:0002692",
+          "label": "ChIP-seq"
+        }
+      ],
+      "library_strategy": "ChIP-Seq",
+      "library_source": "Genomic",
+      "library_selection": "Random",
+      "library_layout": "Single",
+      "extraction_protocol": "NGS",
+      "molecule": "genomic DNA",
+      "molecule_ontology": [
+        {
+          "id": "SO:0000991",
+          "label": "genomic DNA"
+        }
+      ],
+      "experiment_results": [
+        {
+          "identifier": "sample1_01",
+          "description": "test",
+          "filename": "sample1_01.vcf.gz",
+          "file_format": "VCF",
+          "data_output_type": "Derived data",
+          "usage": "visualized",
+          "creation_date": "01-09-2021",
+          "created_by": "Admin",
+          "extra_properties": {
+            "test": "test"
+          }
+        },
+        {
+          "identifier": "sample1_02",
+          "description": "test2",
+          "filename": "sample1_02.cram",
+          "file_format": "CRAM",
+          "data_output_type": "Raw data",
+          "usage": "visualized",
+          "creation_date": "01-09-2021",
+          "created_by": "Admin",
+          "extra_properties": {
+            "test": "test"
+          }
+        }
+      ],
+      "instrument": {
+        "identifier": "instrument:01",
+        "platform": "Illumina",
+        "description": "Test description",
+        "model": "Illumina HiSeq 4000",
+        "extra_properties": {
+          "date": "2021-06-21"
+        }
+      },
+      "extra_properties": {
+        "date_uploaded": "2021-03-16"
+      }
+    },
+    {
+      "id": "experiment:2",
+      "biosample": "sample8",
+      "study_type": "Epigenomics",
+      "experiment_type": "Histone H3K27ac",
+      "experiment_ontology": [
+        {
+          "id": "EFO:0002692",
+          "label": "ChIP-seq"
+        }
+      ],
+      "library_strategy": "ChIP-Seq",
+      "library_source": "Genomic",
+      "library_selection": "Random",
+      "library_layout": "Single",
+      "extraction_protocol": "NGS",
+      "molecule": "genomic DNA",
+      "molecule_ontology": [
+        {
+          "id": "SO:0000991",
+          "label": "genomic DNA"
+        }
+      ],
+      "experiment_results": [
+        {
+          "identifier": "sample8_01",
+          "description": "test",
+          "filename": "sample8_01.vcf.gz",
+          "file_format": "VCF",
+          "data_output_type": "Derived data",
+          "usage": "visualized",
+          "creation_date": "01-09-2021",
+          "created_by": "Admin",
+          "extra_properties": {
+            "test": "test"
+          }
+        },
+        {
+          "identifier": "sample8_02",
+          "description": "test2",
+          "filename": "sample8_02.cram",
+          "file_format": "CRAM",
+          "data_output_type": "Raw data",
+          "usage": "visualized",
+          "creation_date": "01-09-2021",
+          "created_by": "Admin",
+          "extra_properties": {
+            "test": "test"
+          }
+        }
+      ],
+      "instrument": {
+        "identifier": "instrument:01",
+        "platform": "Illumina",
+        "description": "Test description",
+        "model": "Illumina HiSeq 4000",
+        "extra_properties": {
+          "date": "2021-06-21"
+        }
+      },
+      "extra_properties": {
+        "date_uploaded": "2021-03-16"
+      }
+    }
+  ],
+  "resources": [
+    {
+      "name": "Sequence types and features ontology",
+      "version": "2021-02-16",
+      "namespace_prefix": "SO",
+      "id": "SO:2021-02-16",
+      "iri_prefix": "http://purl.obolibrary.org/obo/so.owl#",
+      "url": "http://purl.obolibrary.org/obo/so.owl"
+    }
+  ]
+}

--- a/chord_metadata_service/experiments/tests/example_phenopackets.json
+++ b/chord_metadata_service/experiments/tests/example_phenopackets.json
@@ -1,0 +1,400 @@
+[
+  {
+    "subject": {
+      "id": "ind:NA20509001",
+      "date_of_birth": "1986-10-22",
+      "age": {
+        "age": "P45Y"
+      },
+      "sex": "MALE",
+      "karyotypic_sex": "XY",
+      "taxonomy": {
+        "id": "NCBITaxon:9606",
+        "label": "Homo sapiens"
+      },
+      "extra_properties": {
+        "smoking": "Non-smoker",
+        "covidstatus": "Indeterminate",
+        "death_dc": "Deceased",
+        "mobility": "I have severe problems in walking about",
+        "date_of_consent": "2021-09-22",
+        "lab_test_result_value": 607.82
+      }
+    },
+    "meta_data": {
+      "created_by": "Admin",
+      "submitted_by": "Admin",
+      "resources": [
+        {
+          "id": "NCBITaxon:2018-07-27",
+          "name": "NCBI Taxonomy OBO Edition",
+          "namespace_prefix": "NCBITaxon",
+          "url": "http://purl.obolibrary.org/obo/ncbitaxon.owl",
+          "version": "2018-07-27",
+          "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_"
+        },
+        {
+          "id": "UBERON:2019-06-27",
+          "name": "Uber-anatomy ontology",
+          "namespace_prefix": "UBERON",
+          "url": "http://purl.obolibrary.org/obo/uberon.owl",
+          "version": "2019-06-27",
+          "iri_prefix": "http://purl.obolibrary.org/obo/UBERON"
+        },
+        {
+          "id": "NCIT:2015-09-01",
+          "name": "NCI Thesaurus",
+          "namespace_prefix": "NCIT",
+          "url": "https://ncit.nci.nih.gov",
+          "version": "2015-09-01",
+          "iri_prefix": "https://ncit.nci.nih.gov"
+        }
+      ]
+    },
+    "biosamples": [
+        {
+            "id": "sample1",
+            "individual_id": "ind:NA20509001",
+            "description": "",
+            "sampled_tissue": {
+                "id": "UBERON_0001256",
+                "label": "wall of urinary bladder"
+            },
+            "phenotypic_features": [],
+            "individual_age_at_collection": {
+                "age": "P52Y2M"
+            },
+            "histological_diagnosis": {
+                "id": "NCIT:C39853",
+                "label": "Infiltrating Urothelial Carcinoma"
+            },
+            "tumor_progression": {
+                "id": "NCIT:C84509",
+                "label": "Primary Malignant Neoplasm"
+            },
+            "diagnostic_markers": [],
+            "procedure": {
+                "code": {
+                    "id": "NCIT:C5189",
+                    "label": "Radical Cystoprostatectomy"
+                }
+            },
+            "is_control_sample": false
+        },
+        {
+            "id": "sample2",
+            "individual_id": "ind:NA20509001",
+            "description": "",
+            "sampled_tissue": {
+                "id": "UBERON:0002367",
+                "label": "prostate gland"
+            },
+            "phenotypic_features": [],
+            "individual_age_at_collection": {
+                "age": "P52Y2M"
+            },
+            "histological_diagnosis": {
+                "id": "NCIT:C5596",
+                "label": "Prostate Acinar Adenocarcinoma"
+            },
+            "tumor_progression": {
+                "id": "NCIT:C95606",
+                "label": "Second Primary Malignant Neoplasm"
+            },
+            "tumor_grade": {
+                "id": "NCIT:C28091",
+                "label": "Gleason Score 7"
+            },
+            "disease_stage": [],
+            "diagnostic_markers": [],
+            "procedure": {
+                "code": {
+                    "id": "NCIT:C15189",
+                    "label": "Biopsy"
+                }
+            },
+            "is_control_sample": false
+        },
+        {
+            "id": "sample3",
+            "individual_id": "ind:NA20509001",
+            "description": "",
+            "sampled_tissue": {
+                "id": "UBERON:0001223",
+                "label": "left ureter"
+            },
+            "phenotypic_features": [],
+            "individual_age_at_collection": {
+                "age": "P52Y2M"
+            },
+            "histological_diagnosis": {
+                "id": "NCIT:C38757",
+                "label": "Negative Finding"
+            },
+            "disease_stage": [],
+            "diagnostic_markers": [],
+            "procedure": {
+                "code": {
+                    "id": "NCIT:C15189",
+                    "label": "Biopsy"
+                }
+            },
+            "is_control_sample": false
+        },
+        {
+            "id": "sample4",
+            "individual_id": "ind:NA20509001",
+            "description": "",
+            "sampled_tissue": {
+                "id": "UBERON:0001222",
+                "label": "right ureter"
+            },
+            "phenotypic_features": [],
+            "individual_age_at_collection": {
+                "age": "P52Y2M"
+            },
+            "histological_diagnosis": {
+                "id": "NCIT:C38757",
+                "label": "Negative Finding"
+            },
+            "disease_stage": [],
+            "diagnostic_markers": [],
+            "procedure": {
+                "code": {
+                    "id": "NCIT:C15189",
+                    "label": "Biopsy"
+                }
+            },
+            "is_control_sample": false
+        }
+    ]
+  },
+  {
+    "subject": {
+      "id": "ind:NA20509002",
+      "date_of_birth": "1950-11-22",
+      "age": {
+        "age": "P65Y6M3D"
+      },
+      "sex": "MALE",
+      "karyotypic_sex": "XY",
+      "taxonomy": {
+        "id": "NCBITaxon:9606",
+        "label": "Homo sapiens"
+      },
+      "extra_properties": {
+        "smoking": "Non-smoker",
+        "covidstatus": "Indeterminate",
+        "death_dc": "Deceased",
+        "mobility": "I have severe problems in walking about",
+        "date_of_consent": "2021-09-22",
+        "lab_test_result_value": 607.82
+      }
+    },
+    "meta_data": {
+      "created_by": "Admin",
+      "submitted_by": "Admin",
+      "resources": [
+        {
+          "id": "NCBITaxon:2018-07-27",
+          "name": "NCBI Taxonomy OBO Edition",
+          "namespace_prefix": "NCBITaxon",
+          "url": "http://purl.obolibrary.org/obo/ncbitaxon.owl",
+          "version": "2018-07-27",
+          "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_"
+        },
+        {
+          "id": "UBERON:2019-06-27",
+          "name": "Uber-anatomy ontology",
+          "namespace_prefix": "UBERON",
+          "url": "http://purl.obolibrary.org/obo/uberon.owl",
+          "version": "2019-06-27",
+          "iri_prefix": "http://purl.obolibrary.org/obo/UBERON"
+        },
+        {
+          "id": "NCIT:2015-09-01",
+          "name": "NCI Thesaurus",
+          "namespace_prefix": "NCIT",
+          "url": "https://ncit.nci.nih.gov",
+          "version": "2015-09-01",
+          "iri_prefix": "https://ncit.nci.nih.gov"
+        }
+      ]
+    },
+    "biosamples": [
+        {
+            "id": "sample5",
+            "individual_id": "ind:NA20509002",
+            "description": "",
+            "sampled_tissue": {
+                "id": "UBERON_0001256",
+                "label": "wall of urinary bladder"
+            },
+            "phenotypic_features": [],
+            "individual_age_at_collection": {
+                "age": "P52Y2M"
+            },
+            "histological_diagnosis": {
+                "id": "NCIT:C39853",
+                "label": "Infiltrating Urothelial Carcinoma"
+            },
+            "tumor_progression": {
+                "id": "NCIT:C84509",
+                "label": "Primary Malignant Neoplasm"
+            },
+            "diagnostic_markers": [],
+            "procedure": {
+                "code": {
+                    "id": "NCIT:C5189",
+                    "label": "Radical Cystoprostatectomy"
+                }
+            },
+            "is_control_sample": false
+        },
+        {
+            "id": "sample6",
+            "individual_id": "ind:NA20509002",
+            "description": "",
+            "sampled_tissue": {
+                "id": "UBERON:0002367",
+                "label": "prostate gland"
+            },
+            "phenotypic_features": [],
+            "individual_age_at_collection": {
+                "age": "P52Y2M"
+            },
+            "histological_diagnosis": {
+                "id": "NCIT:C5596",
+                "label": "Prostate Acinar Adenocarcinoma"
+            },
+            "tumor_progression": {
+                "id": "NCIT:C95606",
+                "label": "Second Primary Malignant Neoplasm"
+            },
+            "tumor_grade": {
+                "id": "NCIT:C28091",
+                "label": "Gleason Score 7"
+            },
+            "disease_stage": [],
+            "diagnostic_markers": [],
+            "procedure": {
+                "code": {
+                    "id": "NCIT:C15189",
+                    "label": "Biopsy"
+                }
+            },
+            "is_control_sample": false
+        },
+        {
+            "id": "sample7",
+            "individual_id": "ind:NA20509002",
+            "description": "",
+            "sampled_tissue": {
+                "id": "UBERON:0001223",
+                "label": "left ureter"
+            },
+            "phenotypic_features": [],
+            "individual_age_at_collection": {
+                "age": "P52Y2M"
+            },
+            "histological_diagnosis": {
+                "id": "NCIT:C38757",
+                "label": "Negative Finding"
+            },
+            "disease_stage": [],
+            "diagnostic_markers": [],
+            "procedure": {
+                "code": {
+                    "id": "NCIT:C15189",
+                    "label": "Biopsy"
+                }
+            },
+            "is_control_sample": false
+        }
+    ]
+  },
+  {
+    "subject": {
+      "id": "ind:NA20509003",
+      "date_of_birth": "1930-11-22",
+      "age": {
+        "age": "P75.8Y6M3D"
+      },
+      "sex": "MALE",
+      "karyotypic_sex": "XY",
+      "taxonomy": {
+        "id": "NCBITaxon:9606",
+        "label": "Homo sapiens"
+      },
+      "extra_properties": {
+        "smoking": "Non-smoker",
+        "covidstatus": "Indeterminate",
+        "death_dc": "Deceased",
+        "mobility": "I have severe problems in walking about",
+        "date_of_consent": "2021-09-22",
+        "lab_test_result_value": 607.82
+      }
+    },
+    "meta_data": {
+      "created_by": "Admin",
+      "submitted_by": "Admin",
+      "resources": [
+        {
+          "id": "NCBITaxon:2018-07-27",
+          "name": "NCBI Taxonomy OBO Edition",
+          "namespace_prefix": "NCBITaxon",
+          "url": "http://purl.obolibrary.org/obo/ncbitaxon.owl",
+          "version": "2018-07-27",
+          "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_"
+        },
+        {
+          "id": "UBERON:2019-06-27",
+          "name": "Uber-anatomy ontology",
+          "namespace_prefix": "UBERON",
+          "url": "http://purl.obolibrary.org/obo/uberon.owl",
+          "version": "2019-06-27",
+          "iri_prefix": "http://purl.obolibrary.org/obo/UBERON"
+        },
+        {
+          "id": "NCIT:2015-09-01",
+          "name": "NCI Thesaurus",
+          "namespace_prefix": "NCIT",
+          "url": "https://ncit.nci.nih.gov",
+          "version": "2015-09-01",
+          "iri_prefix": "https://ncit.nci.nih.gov"
+        }
+      ]
+    },
+    "biosamples": [
+        {
+            "id": "sample8",
+            "individual_id": "ind:NA20509003",
+            "description": "",
+            "sampled_tissue": {
+                "id": "UBERON_0001256",
+                "label": "wall of urinary bladder"
+            },
+            "phenotypic_features": [],
+            "individual_age_at_collection": {
+                "age": "P52Y2M"
+            },
+            "histological_diagnosis": {
+                "id": "NCIT:C39853",
+                "label": "Infiltrating Urothelial Carcinoma"
+            },
+            "tumor_progression": {
+                "id": "NCIT:C84509",
+                "label": "Primary Malignant Neoplasm"
+            },
+            "diagnostic_markers": [],
+            "procedure": {
+                "code": {
+                    "id": "NCIT:C5189",
+                    "label": "Radical Cystoprostatectomy"
+                }
+            },
+            "is_control_sample": false
+        }
+    ]
+  }
+]

--- a/chord_metadata_service/experiments/tests/test_api.py
+++ b/chord_metadata_service/experiments/tests/test_api.py
@@ -1,0 +1,133 @@
+import os
+from uuid import uuid4
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+from chord_metadata_service.chord.models import Project, Dataset, TableOwnership, Table
+from chord_metadata_service.chord.tests.constants import VALID_DATA_USE_1
+from chord_metadata_service.chord.data_types import DATA_TYPE_PHENOPACKET, DATA_TYPE_EXPERIMENT
+from chord_metadata_service.chord.ingest import (
+    WORKFLOW_INGEST_FUNCTION_MAP,
+    WORKFLOW_PHENOPACKETS_JSON,
+    WORKFLOW_EXPERIMENTS_JSON,
+)
+
+
+EXAMPLE_INGEST_OUTPUTS_PHENOPACKETS_JSON = {
+    "json_document": os.path.join(os.path.dirname(__file__), "example_phenopackets.json"),
+}
+
+EXAMPLE_INGEST_OUTPUTS_EXPERIMENTS_JSON = {
+    "json_document": os.path.join(os.path.dirname(__file__), "example_experiments.json"),
+}
+
+
+class GetExperimentsAppApisTest(APITestCase):
+    """
+    Test Experiments app APIs.
+    """
+
+    def setUp(self) -> None:
+        """
+        Create two datasets but ingest phenopackets and experiments in just one dataset
+        """
+        p = Project.objects.create(title="Test Project", description="Test")
+        self.d1 = Dataset.objects.create(title="dataset_1", description="Some dataset 1", data_use=VALID_DATA_USE_1,
+                                         project=p)
+        self.d2 = Dataset.objects.create(title="dataset_2", description="Some dataset 2", data_use=VALID_DATA_USE_1,
+                                         project=p)
+        to1 = TableOwnership.objects.create(table_id=uuid4(), service_id=uuid4(), service_artifact="metadata",
+                                            dataset=self.d1)
+        to2 = TableOwnership.objects.create(table_id=uuid4(), service_id=uuid4(), service_artifact="metadata",
+                                            dataset=self.d1)
+        self.t1 = Table.objects.create(ownership_record=to1, name="Table 1", data_type=DATA_TYPE_PHENOPACKET)
+        self.t2 = Table.objects.create(ownership_record=to2, name="Table 2", data_type=DATA_TYPE_EXPERIMENT)
+        WORKFLOW_INGEST_FUNCTION_MAP[WORKFLOW_PHENOPACKETS_JSON](
+            EXAMPLE_INGEST_OUTPUTS_PHENOPACKETS_JSON, self.t1.identifier)
+        WORKFLOW_INGEST_FUNCTION_MAP[WORKFLOW_EXPERIMENTS_JSON](
+            EXAMPLE_INGEST_OUTPUTS_EXPERIMENTS_JSON, self.t2.identifier)
+
+    def test_get_experiments(self):
+        response = self.client.get('/api/experiments')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 2)
+        self.assertEqual(len(response_data["results"]), 2)
+
+    def test_filter_experiments(self):
+        response = self.client.get('/api/experiments?study_type=epigenetics')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 0)
+        self.assertEqual(len(response_data["results"]), 0)
+
+    def test_filter_experiments_by_dataset_1(self):
+        response = self.client.get('/api/experiments?datasets=dataset_1')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 2)
+        self.assertEqual(len(response_data["results"]), 2)
+
+    def test_filter_experiments_by_dataset_2(self):
+        response = self.client.get('/api/experiments?datasets=dataset_2')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 0)
+        self.assertEqual(len(response_data["results"]), 0)
+
+    def test_filter_experiments_by_datasets_list(self):
+        response = self.client.get('/api/experiments?datasets=dataset_2,dataset_1')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 2)
+        self.assertEqual(len(response_data["results"]), 2)
+
+    def test_get_experiment_results(self):
+        response = self.client.get('/api/experimentresults')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 4)
+        self.assertEqual(len(response_data["results"]), 4)
+
+    def test_filter_experiment_results(self):
+        response = self.client.get('/api/experimentresults?file_format=vcf')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 2)
+        self.assertEqual(len(response_data["results"]), 2)
+
+    def test_filter_experiment_results_by_dataset_1(self):
+        response = self.client.get('/api/experimentresults?datasets=dataset_1')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 4)
+        self.assertEqual(len(response_data["results"]), 4)
+
+    def test_filter_experiment_results_by_dataset_2(self):
+        response = self.client.get('/api/experimentresults?datasets=dataset_2')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 0)
+        self.assertEqual(len(response_data["results"]), 0)
+
+    def test_filter_experiment_results_by_datasets_list(self):
+        response = self.client.get('/api/experimentresults?datasets=dataset_2,dataset_1')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 4)
+        self.assertEqual(len(response_data["results"]), 4)
+
+    def test_combine_filters_experiment_results(self):
+        response = self.client.get('/api/experimentresults?datasets=dataset_2,dataset_1&file_format=cram')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 2)
+        self.assertEqual(len(response_data["results"]), 2)
+
+    def test_combine_filters_experiment_results_2(self):
+        # there are no experiments in dataset_2
+        response = self.client.get('/api/experimentresults?datasets=dataset_2&file_format=vcf')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["count"], 0)
+        self.assertEqual(len(response_data["results"]), 0)

--- a/chord_metadata_service/restapi/urls.py
+++ b/chord_metadata_service/restapi/urls.py
@@ -26,6 +26,7 @@ router.register(r'tables', chord_views.TableViewSet)
 
 # Experiments app urls
 router.register(r'experiments', experiment_views.ExperimentViewSet)
+router.register(r'experimentresults', experiment_views.ExperimentResultViewSet)
 
 # Patients app urls
 router.register(r'individuals', individual_views.IndividualViewSet)


### PR DESCRIPTION
This PR:
- Adds `api/experimentresults` endpoint to list all available experiment results.
- Adds the following filters on top of the `api/experimentresults`:
`identifier`, `description`, `filename`, `genome_assembly_id`, `file_format`, `data_output_type`, `usage`, `created_by`, `extra_properties`, `datasets`. All filters can be combined with each other.
- Adds `datasets` filter to `api/experiments`.

Note: The `datasets` filter is filtering by a dataset title and can take a list of datasets separated by comma,
e.g. `?datasets=dataset_1,dataset_2`