### PR TITLE
Features/leaner queries

### DIFF
--- a/chord_metadata_service/chord/tests/constants.py
+++ b/chord_metadata_service/chord/tests/constants.py
@@ -20,6 +20,7 @@ __all__ = [
     "TEST_SEARCH_QUERY_7",
     "TEST_SEARCH_QUERY_8",
     "TEST_SEARCH_QUERY_9",
+    "TEST_SEARCH_QUERY_10",
     "TEST_FHIR_SEARCH_QUERY",
 ]
 
@@ -249,4 +250,6 @@ TEST_SEARCH_QUERY_6 = ["#ico", ["#resolve", "biosamples", "[item]", "sampled_tis
 TEST_SEARCH_QUERY_7 = ["#eq", ["#resolve", "experiment_results", "[item]", "file_format"], "VCF"]
 TEST_SEARCH_QUERY_8 = ["#ico", ["#resolve", "experiment_type"], "chromatin"]
 TEST_SEARCH_QUERY_9 = ["#eq", ["#resolve", "subject", "id"], "patient:1"]
+TEST_SEARCH_QUERY_10 = ["#in", ["#resolve", "biosamples", "[item]", "id"],
+                        ["#list", "biosample_id:1", "biosample_id:2"]]
 TEST_FHIR_SEARCH_QUERY = {"query": {"match": {"gender": "FEMALE"}}}

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -515,7 +515,7 @@ class SearchTest(APITestCase):
 
     def test_private_table_search_bento_search_results(self):
         # Valid query to search for biosample id in list
-        # Output as Bento search (a list of 3 values)
+        # Output as Bento search (a list of 5 values)
 
         d = {
             "query": TEST_SEARCH_QUERY_10,
@@ -527,14 +527,14 @@ class SearchTest(APITestCase):
             self.assertEqual(r.status_code, status.HTTP_200_OK)
             c = r.json()
             self.assertEqual(len(c["results"]), 1)  # 1 matching phenopacket
-            self.assertTrue(len(c["results"][0]), 4)    # 4 columns by result
+            self.assertEqual(len(c["results"][0]), 5)    # 5 columns by result
             self.assertListEqual(
-                ["subject_id", "alternate_ids", "biosamples", "num_experiments"],
+                ["subject_id", "table_id", "alternate_ids", "biosamples", "num_experiments"],
                 list(c["results"][0].keys()))
 
     def test_private_search_bento_search_results(self):
         # Valid query to search for biosample id in list
-        # Output as a bento search is not implemented
+        # Output as a bento search is valid
 
         d = {
             "query": TEST_SEARCH_QUERY_10,
@@ -544,9 +544,11 @@ class SearchTest(APITestCase):
 
         for method in POST_GET:
             r = self._search_call("private-search", data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
             c = r.json()
-            print(c)
-            self.assertEqual(r.status_code, status.HTTP_501_NOT_IMPLEMENTED)
+            table_id = list(c["results"].keys())[0]
+            matches = c["results"][table_id]["matches"]
+            self.assertEqual(len(matches), 1)   # 1 matching phenopacket
 
     @patch('chord_metadata_service.chord.views_search.es')
     def test_fhir_search(self, mocked_es):

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -482,6 +482,39 @@ class SearchTest(APITestCase):
             self.assertEqual(len(c["results"]), 2)  # 2 biosamples id for the matching phenopacket
             self.assertTrue(all([isinstance(item, str) for item in c["results"]]))
 
+    def test_private_table_search_bento_search_results(self):
+        # Valid query to search for biosample id in list
+        # Output as Bento search (a list of 3 values)
+
+        d = {
+            "query": TEST_SEARCH_QUERY_10,
+            "output": "bento_search_result",
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 1)  # 1 matching phenopacket
+            self.assertTrue(len(c["results"][0]), 3)    # 3 columns by result
+            self.assertListEqual(["subject_id", "biosamples", "num_experiments"], list(c["results"][0].keys()))
+
+    def test_private_search_bento_search_results(self):
+        # Valid query to search for biosample id in list
+        # Output as a bento search is not implemented
+
+        d = {
+            "query": TEST_SEARCH_QUERY_10,
+            "output": "bento_search_result",
+            "data_type": "phenopacket",
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-search", data=d, method=method)
+            c = r.json()
+            print(c)
+            self.assertEqual(r.status_code, status.HTTP_501_NOT_IMPLEMENTED)
+
     @patch('chord_metadata_service.chord.views_search.es')
     def test_fhir_search(self, mocked_es):
         mocked_es.search.return_value = SEARCH_SUCCESS

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -531,6 +531,7 @@ class SearchTest(APITestCase):
             self.assertListEqual(
                 ["subject_id", "alternate_ids", "biosamples", "num_experiments"],
                 list(c["results"][0].keys()))
+            self.assertIsInstance(c["results"][0]["alternate_ids"], list)
 
     def test_private_search_bento_search_results(self):
         # Valid query to search for biosample id in list

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -36,6 +36,7 @@ from .constants import (
     TEST_SEARCH_QUERY_7,
     TEST_SEARCH_QUERY_8,
     TEST_SEARCH_QUERY_9,
+    TEST_SEARCH_QUERY_10,
     TEST_FHIR_SEARCH_QUERY,
 )
 from ..models import Project, Dataset, TableOwnership, Table
@@ -446,6 +447,23 @@ class SearchTest(APITestCase):
             c = r.json()
             self.assertEqual(len(c["results"]), 1)
             self.assertIn("patient:1", [phenopacket["subject"]["id"] for phenopacket in c["results"]])
+
+    def test_private_table_search_13(self):
+        # Valid query to search for biosample id in list
+
+        d = {
+            "query": TEST_SEARCH_QUERY_10
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 2)
+            self.assertIn("biosample_id:1", [b["id"]
+                                             for phenopacket in c["results"]
+                                             for b in phenopacket["biosamples"]
+                                             ])
 
     @patch('chord_metadata_service.chord.views_search.es')
     def test_fhir_search(self, mocked_es):

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -459,7 +459,7 @@ class SearchTest(APITestCase):
             r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
             self.assertEqual(r.status_code, status.HTTP_200_OK)
             c = r.json()
-            self.assertEqual(len(c["results"]), 2)
+            self.assertEqual(len(c["results"]), 1)  # 1 phenopacket that contains 2 matching biosamples
             self.assertIn("biosample_id:1", [b["id"]
                                              for phenopacket in c["results"]
                                              for b in phenopacket["biosamples"]

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -550,6 +550,25 @@ class SearchTest(APITestCase):
             matches = c["results"][table_id]["matches"]
             self.assertEqual(len(matches), 1)   # 1 matching phenopacket
 
+    def test_private_search_values_list(self):
+        # Valid query to search for biosample id in list
+        # Output as a list of values
+
+        d = {
+            "query": TEST_SEARCH_QUERY_10,
+            "output": "values_list",
+            "field": '["biosamples", "[item]", "id"]',
+            "data_type": "phenopacket",
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-search", data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            table_id = list(c["results"].keys())[0]
+            matches = c["results"][table_id]["matches"]
+            self.assertEqual(len(matches), 2)   # 2 biosamples in list
+
     @patch('chord_metadata_service.chord.views_search.es')
     def test_fhir_search(self, mocked_es):
         mocked_es.search.return_value = SEARCH_SUCCESS

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -515,7 +515,7 @@ class SearchTest(APITestCase):
 
     def test_private_table_search_bento_search_results(self):
         # Valid query to search for biosample id in list
-        # Output as Bento search (a list of 5 values)
+        # Output as Bento search (a list of 4 values)
 
         d = {
             "query": TEST_SEARCH_QUERY_10,
@@ -527,9 +527,9 @@ class SearchTest(APITestCase):
             self.assertEqual(r.status_code, status.HTTP_200_OK)
             c = r.json()
             self.assertEqual(len(c["results"]), 1)  # 1 matching phenopacket
-            self.assertEqual(len(c["results"][0]), 5)    # 5 columns by result
+            self.assertEqual(len(c["results"][0]), 4)    # 4 columns by result
             self.assertListEqual(
-                ["subject_id", "table_id", "alternate_ids", "biosamples", "num_experiments"],
+                ["subject_id", "alternate_ids", "biosamples", "num_experiments"],
                 list(c["results"][0].keys()))
 
     def test_private_search_bento_search_results(self):

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -465,6 +465,23 @@ class SearchTest(APITestCase):
                                              for b in phenopacket["biosamples"]
                                              ])
 
+    def test_private_table_search_values_list(self):
+        # Valid query to search for biosample id in list
+        # Output as a list of values from a single field
+
+        d = {
+            "query": TEST_SEARCH_QUERY_10,
+            "output": "values_list",
+            "field": '["biosamples", "[item]", "id"]'
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 2)  # 2 biosamples id for the matching phenopacket
+            self.assertTrue(all([isinstance(item, str) for item in c["results"]]))
+
     @patch('chord_metadata_service.chord.views_search.es')
     def test_fhir_search(self, mocked_es):
         mocked_es.search.return_value = SEARCH_SUCCESS

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -482,6 +482,37 @@ class SearchTest(APITestCase):
             self.assertEqual(len(c["results"]), 2)  # 2 biosamples id for the matching phenopacket
             self.assertTrue(all([isinstance(item, str) for item in c["results"]]))
 
+    def test_private_table_experiment_search_values_list(self):
+        # Valid query to search for experiment
+        # Output as a list of values from a single field
+
+        d = {
+            "query": TEST_SEARCH_QUERY_7,
+            "output": "values_list",
+            "field": '["biosample"]'
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.t_exp.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+            self.assertEqual(len(c["results"]), 1)  # 1 biosamples id in the database
+            self.assertEqual(c["results"][0], str(self.biosample_1.id))
+
+    def test_private_table_search_values_list_invalid_field_syntax(self):
+        # Valid query to search for biosample id in list
+        # Output as a list of values from a single field badly defined
+
+        d = {
+            "query": TEST_SEARCH_QUERY_10,
+            "output": "values_list",
+            "field": '["biosamples", "[item]"'
+        }
+
+        for method in POST_GET:
+            r = self._search_call("private-table-search", args=[str(self.table.identifier)], data=d, method=method)
+            self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_private_table_search_bento_search_results(self):
         # Valid query to search for biosample id in list
         # Output as Bento search (a list of 3 values)

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -527,8 +527,10 @@ class SearchTest(APITestCase):
             self.assertEqual(r.status_code, status.HTTP_200_OK)
             c = r.json()
             self.assertEqual(len(c["results"]), 1)  # 1 matching phenopacket
-            self.assertTrue(len(c["results"][0]), 3)    # 3 columns by result
-            self.assertListEqual(["subject_id", "biosamples", "num_experiments"], list(c["results"][0].keys()))
+            self.assertTrue(len(c["results"][0]), 4)    # 4 columns by result
+            self.assertListEqual(
+                ["subject_id", "alternate_ids", "biosamples", "num_experiments"],
+                list(c["results"][0].keys()))
 
     def test_private_search_bento_search_results(self):
         # Valid query to search for biosample id in list

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -320,7 +320,7 @@ def phenopacket_query_results(query, params, options=None):
         # Only an array of values.
         field_lookup = get_field_lookup(options.get("field", []))
         return queryset.values_list(field_lookup, flat=True)
-    if output_format == "bento_search_result":
+    if output_format == OUTPUT_FORMAT_BENTO_SEARCH_RESULT:
         # Results displayed as 3 columns: "individuals ID", [Biosamples list...], number of experiments
         return queryset.values("subject_id").annotate(
             biosamples=ArrayAgg("biosamples__id"),  # Postgre specific: aggregates multiple values in a list

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -35,6 +35,9 @@ from .data_types import DATA_TYPE_EXPERIMENT, DATA_TYPE_MCODEPACKET, DATA_TYPE_P
 from .models import Dataset, TableOwnership, Table
 from .permissions import ReadOnly, OverrideOrSuperUserOnly
 
+OUTPUT_FORMAT_VALUES_LIST = "values_list"
+OUTPUT_FORMAT_BENTO_SEARCH_RESULTS = "bento_search_results"
+
 
 @api_view(["GET"])
 @permission_classes([AllowAny])
@@ -282,7 +285,7 @@ def experiment_query_results(query, params, options=None):
         .filter(id__in=data_type_results(query, params, "id"))
 
     output_format = options.get("output") if options else None
-    if output_format == "values_list":
+    if output_format == OUTPUT_FORMAT_VALUES_LIST:
         field_lookup = get_field_lookup(options.get("field", []))
         return queryset.values_list(field_lookup, flat=True)
 
@@ -298,7 +301,7 @@ def mcodepacket_query_results(query, params, options=None):
     )
 
     output_format = options.get("output") if options else None
-    if output_format == "values_list":
+    if output_format == OUTPUT_FORMAT_VALUES_LIST:
         field_lookup = get_field_lookup(options.get("field", []))
         return queryset.values_list(field_lookup, flat=True)
 
@@ -316,7 +319,7 @@ def phenopacket_query_results(query, params, options=None):
         .filter(id__in=data_type_results(query, params, "id"))
 
     output_format = options.get("output") if options else None
-    if output_format == "values_list":
+    if output_format == OUTPUT_FORMAT_VALUES_LIST:
         field_lookup = get_field_lookup(options.get("field", []))
         return queryset.values_list(field_lookup, flat=True)
 
@@ -370,7 +373,7 @@ def search(request, internal_data=False):
     query_function = QUERY_RESULTS_FN[data_type]
     queryset = query_function(compiled_query, query_params, search_params)
 
-    if search_params["output"] == "values_list":
+    if search_params["output"] == OUTPUT_FORMAT_VALUES_LIST:
         return Response(build_search_response(list(queryset), start))
 
     return Response(build_search_response({
@@ -611,7 +614,7 @@ def chord_table_search(search_params, table_id, start, internal=False) -> Tuple[
     if not internal:
         return queryset.exists(), None    # True if at least one match
 
-    if search_params["output"] == "values_list":
+    if search_params["output"] == OUTPUT_FORMAT_VALUES_LIST:
         return list(queryset), None
 
     debug_log(f"Started fetching from queryset and serializing data at {datetime.now() - start}")

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -7,7 +7,7 @@ from bento_lib.search import build_search_response, postgres
 from collections import Counter
 from datetime import datetime
 from django.db import connection
-from django.db.models import Count
+from django.db.models import Count, F
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.conf import settings
 from django.views.decorators.cache import cache_page
@@ -321,8 +321,9 @@ def phenopacket_query_results(query, params, options=None):
         field_lookup = get_field_lookup(options.get("field", []))
         return queryset.values_list(field_lookup, flat=True)
     if output_format == OUTPUT_FORMAT_BENTO_SEARCH_RESULT:
-        # Results displayed as 3 columns: "individuals ID", [Biosamples list...], number of experiments
-        return queryset.values("subject_id").annotate(
+        # Results displayed as 4 columns:
+        # "individuals ID", [Alternate ids list], [Biosamples list...], number of experiments
+        return queryset.values("subject_id", alternate_ids=F("subject__alternate_ids")).annotate(
             biosamples=ArrayAgg("biosamples__id"),  # Postgre specific: aggregates multiple values in a list
             num_experiments=Count("biosamples__experiment")
         )

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -278,18 +278,31 @@ def data_type_results(query, params, key="id"):
 def experiment_query_results(query, params, options=None):
     # TODO: possibly a quite inefficient way of doing things...
     # TODO: Prefetch related biosample or no?
-    return Experiment.objects \
-        .filter(id__in=data_type_results(query, params, "id")) \
-        .select_related(*EXPERIMENT_SELECT_REL) \
+    queryset = Experiment.objects\
+        .filter(id__in=data_type_results(query, params, "id"))
+
+    output_format = options.get("output") if options else None
+    if output_format == "values_list":
+        field_lookup = get_field_lookup(options.get("field", []))
+        return queryset.values_list(field_lookup, flat=True)
+
+    return queryset.select_related(*EXPERIMENT_SELECT_REL) \
         .prefetch_related(*EXPERIMENT_PREFETCH)
 
 
 def mcodepacket_query_results(query, params, options=None):
     # TODO: possibly a quite inefficient way of doing things...
     # TODO: select_related / prefetch_related for instant performance boost!
-    return MCodePacket.objects.filter(
+    queryset = MCodePacket.objects.filter(
         id__in=data_type_results(query, params, "id")
     )
+
+    output_format = options.get("output") if options else None
+    if output_format == "values_list":
+        field_lookup = get_field_lookup(options.get("field", []))
+        return queryset.values_list(field_lookup, flat=True)
+
+    return queryset
 
 
 def phenopacket_query_results(query, params, options=None):

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -321,9 +321,9 @@ def phenopacket_query_results(query, params, options=None):
         field_lookup = get_field_lookup(options.get("field", []))
         return queryset.values_list(field_lookup, flat=True)
     if output_format == "bento_search_result":
-        # Results displayed as 3 columns: individuals ID/Biosamples list/number of experiments
+        # Results displayed as 3 columns: "individuals ID", [Biosamples list...], number of experiments
         return queryset.values("subject_id").annotate(
-            biosamples=ArrayAgg("biosamples__id"),
+            biosamples=ArrayAgg("biosamples__id"),  # Postgre specific: aggregates multiple values in a list
             num_experiments=Count("biosamples__experiment")
         )
 
@@ -551,7 +551,8 @@ def get_chord_search_parameters(request, data_type=None):
     the information to make the search.
     - parameters:
         - request: DRF Request object. See `chord_private_table_search` for a
-        detail of the possible values
+        detail of the possible values. Note that the "output" parameter is not
+        implemented for this search.
         - data_type: optional argument. Can be "experiment"/"phenopacket"/"mcodepacket"
             This value is provided for the chord searches that are restricted to
             a specific table (values inferred from the table properties)
@@ -708,7 +709,7 @@ def chord_private_table_search(request, table_id):
         ["#eq", ["#resolve", "experiment_results", "[item]", "file_format"], "VCF"]
         Note: for GET method, it must be encoded as a JSON string.
     - optional parameters:
-        - output: predefined output types in {"values_list", }
+        - output: predefined output types in {"values_list", "bento_search_result"}
           If not set, the objects in the results
           set will be serialized using the default serializer for this data-type
           (for example: phenopackets serializer)

--- a/chord_metadata_service/restapi/schema_utils.py
+++ b/chord_metadata_service/restapi/schema_utils.py
@@ -38,11 +38,11 @@ def _searchable_field(operations: List[str], order: int, queryable: str = "all",
 
 
 def search_optional_eq(order: int, queryable: str = "all"):
-    return _searchable_field(["eq"], order, queryable, multiple=False)
+    return _searchable_field(["eq", "in"], order, queryable, multiple=False)
 
 
 def search_optional_str(order: int, queryable: str = "all", multiple: bool = False):
-    return _searchable_field(["eq", "ico"], order, queryable, multiple)
+    return _searchable_field(["eq", "ico", "in"], order, queryable, multiple)
 
 
 def tag_schema_with_search_properties(schema, search_descriptions: Optional[dict]):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ appdirs==1.4.4
 asgiref==3.3.1
 attrs==20.3.0
 Babel==2.9.1
-bento-lib==2.1.0
+bento-lib==2.3.0
 certifi==2020.12.5
 cffi==1.14.5
 chardet==4.0.0


### PR DESCRIPTION
This PR implements new features to improve the performance of the "federated" search in Bento.

# Context of the PR
The federation service hits Katsu on the /private/[table-id]/search/ url with a query (either POST or GET) containing a `query` parameter which is a string in the format of bento-lib free form queries. The `table-id` extracted from the URL is used to fetch the table properties such as its `data-type` (i.e. "phenopacket", "mcodepacket", "experiment")

Within katsu, the `query` parameter is converted to an SQL statement using bento-lib and psycopg2. This returns a list of IDs for the given table `data_type`. This list of ids is used in a second query made via the Django ORM to the model corresponding to the `data_type` (for example, search for all phenopackets matching this list of IDs)

In general, the ORM also prefetches related records from the accompagnying tables (for examples Biosamples related with the list of phenopackets).

The last step is the serialization of the results from the queries. This makes use of serializers defined for the different Katsu applications (i.e. the serializer for phenopackets also calls the serializers for Patients and for Biosamples,... when traversing the list of results). This last step takes the longest time and produces a bloated response.

# New features
The federation service aggregates results using a "linked field" that is defined at the level of the Dataset object and is common between all the queried data_types. The main idea here is to reduce the amount of data transferred just to the list of ids matching the query for the "linked field".

To do that 2 optional parameters are added to this PR:
- `output` which describes a format expected for the response. In the previous case it is `values_list` which would return a result containing an array of values (not a nested object)
- `field` which is the field to use for fetching this value. The field syntax is given using the bento-lib syntax, which is also the syntax used for the Dataset/linked_field_sets property

In a first attempt I've tried to do without the `field` property, and trying to extract it directly from the dataset table based on the table data_type. Even if the code was working, this could have lead to unexpected results from the requester, for example in the case when multiple sets of linked fields had been defined. Having `field` as a parameter provided by the sender simplifies the code and ensures that the service that asks for the data is responsible for defining what it requires.

Note also that I've tried to name the `output` parameter `format` in a first place. This worked well in a POST request, but caused issues when doing a GET request, due to Django REST Framework that tries to automatically find a Renderer class corresponding to this format. It would have required substantial development to make this work in the broader context of DRF, both for GET and POST queries which is why the parameter name `output` has been chosen instead.

The second feature applies to the case of bento-web interface where only a subset of the values from the phenopackets is displayed to the user (subject id, list of matching biosamples, number of related experiments). In a second step of the search by the federation service, once all the results have been collated and intersected, a new query containing the intersection of list of ids is sent, with the `output` parameter set to `bento_search_result`. The `field` parameter does not apply in this case.

## How to test
- The general test suite must pass
- using the swagger API, try to reach the /private/{table_id}/search endpoint and run queries with the given `output` and `field` parameters.