### PR TITLE
months before october have no reported values

### DIFF
--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -325,7 +325,7 @@ def get_date_stats(field_props):
     bins = []
     if start:   # at least one month
         for year, month in monthly_generator(start, end or start):
-            key = f"{year}-{month}"
+            key = f"{year}-{month:02d}"
             label = f"{month_abbr[month].capitalize()} {year}"    # convert key as yyyy-mm to `abbreviated month yyyy`
             v = stats.get(key, 0)
             bins.append({


### PR DESCRIPTION
This is due to an incorrect key computation where dates like `2020-5`
would be generated instead of `2020-05`.