### PR TITLE
Features/fast text search

### DIFF
--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -115,8 +115,8 @@ class IndividualBatchViewSet(BatchViewSet):
     content_negotiation_class = FormatInPostContentNegotiation
 
     def get_queryset(self):
-        individual_id = self.request.data.get("id", None)
-        filter_by_id = {"id__in": individual_id} if individual_id else {}
+        individual_ids = self.request.data.get("id", None)
+        filter_by_id = {"id__in": individual_ids} if individual_ids else {}
         queryset = Individual.objects.filter(**filter_by_id)\
             .prefetch_related(
                 *(f"phenopackets__{p}" for p in PHENOPACKET_PREFETCH if p != "subject"),

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -9,6 +9,8 @@ from rest_framework.test import APITestCase
 from chord_metadata_service.patients.models import Individual
 from chord_metadata_service.restapi.tests.constants import CONFIG_PUBLIC_TEST, CONFIG_PUBLIC_TEST_SEARCH_SEX_ONLY
 from chord_metadata_service.restapi.utils import iso_duration_to_years
+from chord_metadata_service.phenopackets.tests import constants as ph_c
+from chord_metadata_service.phenopackets import models as ph_m
 
 from . import constants as c
 
@@ -153,6 +155,10 @@ class IndividualFullTextSearchTest(APITestCase):
     def setUp(self):
         self.individual_one = Individual.objects.create(**c.VALID_INDIVIDUAL)
         self.individual_two = Individual.objects.create(**c.VALID_INDIVIDUAL_2)
+        self.metadata_1 = ph_m.MetaData.objects.create(**ph_c.VALID_META_DATA_1)
+        self.phenopacket_1 = ph_m.Phenopacket.objects.create(
+            **ph_c.valid_phenopacket(subject=self.individual_one, meta_data=self.metadata_1)
+        )
 
     def test_search(self):
         get_resp_1 = self.client.get('/api/individuals?search=P49Y')

--- a/chord_metadata_service/restapi/api_renderers.py
+++ b/chord_metadata_service/restapi/api_renderers.py
@@ -169,27 +169,10 @@ class IndividualCSVRenderer(JSONRenderer):
 
 
 class IndividualBentoSearchRenderer(JSONRenderer):
+    """
+    This renderer directly maps bento_search_result to the JSON Renderer
+    Note: this seems necessary to be able to use the format parameter
+    "bento_search_result" in the Individual ViewSet.
+    """
     media_type = 'application/json'
     format = OUTPUT_FORMAT_BENTO_SEARCH_RESULT
-
-    def render(self, data, media_type=None, renderer_context=None):
-        individuals = []
-        for individual in data.get('results', []):
-            ind_obj = {
-                'subject_id': individual['id'],
-                'alternate_ids': individual.get('alternate_ids', []),   # may be NULL
-                'biosamples': [],
-                'num_experiments': 0
-            }
-            if 'phenopackets' in individual:
-                ids = []
-                for p in individual['phenopackets']:
-                    if 'biosamples' in p:
-                        for biosample in p['biosamples']:
-                            ids.append(biosample['id'])
-                            if 'experiments' in biosample:
-                                ind_obj['num_experiments'] += len(biosample['experiments'])
-                ind_obj['biosamples'] = ids
-            individuals.append(ind_obj)
-        data['results'] = individuals
-        return super(IndividualBentoSearchRenderer, self).render(data, self.media_type, renderer_context)

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -50,10 +50,10 @@ def parse_onset(onset):
     if 'age' in onset:
         return onset['age']
     # age ontology
-    elif 'id' and 'label' in onset:
+    elif 'id' in onset and 'label' in onset:
         return f"{onset['label']} {onset['id']}"
     # age range
-    elif 'start' and 'end' in onset:
+    elif 'start' in onset and 'end' in onset:
         if 'age' in onset['start'] and 'age' in onset['end']:
             return f"{onset['start']['age']} - {onset['end']['age']}"
     else:


### PR DESCRIPTION
This PR speeds up the keyword based search in Bento by skipping the usage of the IndividualSerializer

## Some context about DRF ViewSets
A ViewSet in Django Rest Framework abstracts all the operations related to the controller part.
It defines a couple of methods such as `details` which is called with URLS of the form `/api/individuals/indiv:id` with a GET method to output the details about a single record. The `list` method which is overridden in this PR, is called by a GET request on an url of the form `api/individuals/`.
This class defines also some properties such as:
- serializer_class: a class that receives a queryset and converts it to a python object
- renderer_classes: a list of classes that receive a serialized object and convert it to an http response
- filter_backends: a list of filter objects which receive a queryset and a request object, and apply some filtering to the queryset based on the parameters of the request
- `filterset_class`: comes from the Django_filter library and is used to facilitate the definition of filters based on request parameters. This is where the logic for the fulltext search is defined
- queryset: a Django query definition

## Code logic
in this PR, the `list` method is overridden to test for the format used as a parameter. In case of bento_search_results, the `queryset` is manually managed to apply the filtering using the defined `filterset_class` and query for related phenopackets using the expected fields for the bento search response. At the end of the method a Response is returned which takes directly the list of results from the queryset, instead of going through serialization.

## To test
The test suite should work
The PR can be tested in the context of Bento. None of the other search functionality shall be broken.